### PR TITLE
fixes the go.mod spec

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
 module github.com/jentz/vigilant-dollop
 
-go 1.21.6
+go 1.21
+


### PR DESCRIPTION
The patch version should not be included in the minimum go version in go.mod.