### PR TITLE
Subcommands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,6 @@ jobs:
       - name: Get dependencies
         run: go mod download
       - name: Build
-        run: go build -v cmd/oidc-cli.go
+        run: go build -v -o oidc-cli cmd/**
       - name: Run tests
         run: go test -v ./...

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,7 +17,7 @@ builds:
       - linux
       - windows
       - darwin
-    main: ./cmd/oidc-cli.go
+    main: ./cmd/
     binary: oidc-cli
 
 archives:

--- a/README.md
+++ b/README.md
@@ -4,16 +4,21 @@ Command-line OIDC client, get a token without all the fuss
 ## Usage
 
 ```bash
-Usage: oidc-cli [flags]
-       setup an openid client with the callback url : http://localhost:9555/callback and set below flags to get a token response
+oidc-cli is a command-line OIDC client, get a token without all the fuss
+
+Usage:
+  oidc-cli [flags] <command> [command-flags]
+
+Commands:
+  authorization_code: Uses the authorization code flow to get a token response
+  client_credentials: Uses the client credentials flow to get a token response
+  help              : Prints help
+
 Flags:
-        --discovery-url         OpenID discovery endpoint. If provided, authorization-url and token-url will be ignored.
-        --authorization-url     authorization URL. Default value is https://localhost:9443/oauth2/authorize.
-        --token-url             token URL. Default value is https://localhost:9443/oauth2/token
-        --client-id             client ID.
-        --client-secret         client secret.
-        --scopes                scopes.
+
+Run `oidc-cli <command> -h` to get help for a specific command
 ```
+
 ## Installing
 
 Installing with homebrew
@@ -27,13 +32,12 @@ You can also download a suitable release for your platform from the [releases pa
 ## Run
 
 ```bash
-go run cmd/oidc-cli.go --authorization-url <authorization-url> --token-url <token-url> --client-id <client-id> --client-secret <client-secret>
+go run cmd/** authorization_code --authorization-url <authorization-url> --token-url <token-url> --client-id <client-id> --client-secret <client-secret> --scopes "openid profile"
 ```
-
 
 ## Build
 
 ```bash
-go build  cmd/oidc-cli.go
+ go build -v -o oidc-cli ./cmd/**
 ```
 

--- a/authorization_code.go
+++ b/authorization_code.go
@@ -9,15 +9,7 @@ type AuthorizationCodeConfig struct {
 	Scopes                string
 }
 
-type AuthorizationCodeCmd struct {
-	config *AuthorizationCodeConfig
-}
-
-func NewAuthorizationCodeCmd(config *AuthorizationCodeConfig) *AuthorizationCodeCmd {
-	return &AuthorizationCodeCmd{config: config}
-}
-
-func (c *AuthorizationCodeCmd) Run() error {
-	HandleOpenIDFlow(c.config.ClientID, c.config.ClientSecret, c.config.Scopes, "http://localhost:9555/callback", c.config.DiscoveryEndpoint, c.config.AuthorizationEndpoint, c.config.TokenEndpoint)
+func (c *AuthorizationCodeConfig) Run() error {
+	HandleOpenIDFlow(c.ClientID, c.ClientSecret, c.Scopes, "http://localhost:9555/callback", c.DiscoveryEndpoint, c.AuthorizationEndpoint, c.TokenEndpoint)
 	return nil
 }

--- a/authorization_code.go
+++ b/authorization_code.go
@@ -1,0 +1,23 @@
+package oidc
+
+type AuthorizationCodeConfig struct {
+	DiscoveryEndpoint     string
+	AuthorizationEndpoint string
+	TokenEndpoint         string
+	ClientID              string
+	ClientSecret          string
+	Scopes                string
+}
+
+type AuthorizationCodeCmd struct {
+	config *AuthorizationCodeConfig
+}
+
+func NewAuthorizationCodeCmd(config *AuthorizationCodeConfig) *AuthorizationCodeCmd {
+	return &AuthorizationCodeCmd{config: config}
+}
+
+func (c *AuthorizationCodeCmd) Run() error {
+	HandleOpenIDFlow(c.config.ClientID, c.config.ClientSecret, c.config.Scopes, "http://localhost:9555/callback", c.config.DiscoveryEndpoint, c.config.AuthorizationEndpoint, c.config.TokenEndpoint)
+	return nil
+}

--- a/cmd/authorization_code_cfg.go
+++ b/cmd/authorization_code_cfg.go
@@ -6,7 +6,7 @@ import (
 	oidc "github.com/jentz/vigilant-dollop"
 )
 
-func parseAuthorizationCodeFlags(name string, args []string) (config interface{}, output string, err error) {
+func parseAuthorizationCodeFlags(name string, args []string) (config oidc.Command, output string, err error) {
 	flags := flag.NewFlagSet(name, flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)
@@ -24,9 +24,4 @@ func parseAuthorizationCodeFlags(name string, args []string) (config interface{}
 	}
 
 	return &conf, buf.String(), nil
-}
-
-func authorizationCodeCmd(config interface{}) error {
-	cmd := oidc.NewAuthorizationCodeCmd(config.(*oidc.AuthorizationCodeConfig))
-	return cmd.Run()
 }

--- a/cmd/authorization_code_cmd.go
+++ b/cmd/authorization_code_cmd.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	oidc "github.com/jentz/vigilant-dollop"
+)
+
+func parseAuthorizationCodeFlags(name string, args []string) (config interface{}, output string, err error) {
+	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+	var buf bytes.Buffer
+	flags.SetOutput(&buf)
+
+	var conf oidc.AuthorizationCodeConfig
+	flags.StringVar(&conf.DiscoveryEndpoint, "discovery-url", "", "set OIDC discovery url")
+	flags.StringVar(&conf.AuthorizationEndpoint, "authorization-url", "", "set OIDC authorization url")
+	flags.StringVar(&conf.TokenEndpoint, "token-url", "", "set OIDC token url")
+	flags.StringVar(&conf.ClientID, "client-id", "", "set client ID")
+	flags.StringVar(&conf.ClientSecret, "client-secret", "", "set client secret")
+	flags.StringVar(&conf.Scopes, "scopes", "", "set scopes as a space separated list")
+	err = flags.Parse(args)
+	if err != nil {
+		return nil, buf.String(), err
+	}
+
+	return &conf, buf.String(), nil
+}
+
+func authorizationCodeCmd(config interface{}) error {
+	cmd := oidc.NewAuthorizationCodeCmd(config.(*oidc.AuthorizationCodeConfig))
+	return cmd.Run()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,3 @@
 module github.com/jentz/vigilant-dollop
 
 go 1.21
-

--- a/oidc.go
+++ b/oidc.go
@@ -14,6 +14,10 @@ import (
 	"time"
 )
 
+type Command interface {
+	Run() error
+}
+
 type callbackEndpoint struct {
 	server         *http.Server
 	code           string


### PR DESCRIPTION
* changes cli interface to use subcommands

This is the first step to bringing more structure to the CLI and
breaking things down into sub commands and keeping the parsing of them
separate we should have an easier time adding validation and tests.

References:

* https://eli.thegreenplace.net/2020/testing-flag-parsing-in-go-programs/
* https://www.janekbieser.dev/posts/cli-app-with-subcommands-in-go/