### PR TITLE
adds support for pkce

### DIFF
--- a/authorization_code.go
+++ b/authorization_code.go
@@ -3,20 +3,17 @@ package oidc
 type AuthorizationCodeFlow struct {
 	ServerConfig *ServerConfig
 	ClientConfig *ClientConfig
-	Scopes	     *string
-	CallbackURI  *string
+	FlowConfig   *AuthorizationCodeFlowConfig
 }
 
-func NewAuthorizationCodeFlow(serverConf *ServerConfig, clientConf *ClientConfig, scopes, callbackURI *string) *AuthorizationCodeFlow {
-	return &AuthorizationCodeFlow{
-		ServerConfig: serverConf,
-		ClientConfig: clientConf,
-		Scopes: scopes,
-		CallbackURI: callbackURI,
-	}
+type AuthorizationCodeFlowConfig struct {
+	Scopes      string
+	CallbackURI string
 }
 
 func (c *AuthorizationCodeFlow) Run() error {
-	HandleOpenIDFlow(c.ClientConfig.ClientID, c.ClientConfig.ClientSecret, *c.Scopes, "http://localhost:9555/callback", c.ServerConfig.DiscoveryEndpoint, c.ServerConfig.AuthorizationEndpoint, c.ServerConfig.TokenEndpoint)
+	c.ServerConfig.DiscoverEndpoints()
+
+	HandleOpenIDFlow(c.ClientConfig.ClientID, c.ClientConfig.ClientSecret, c.FlowConfig.Scopes, "http://localhost:9555/callback", c.ServerConfig.DiscoveryEndpoint, c.ServerConfig.AuthorizationEndpoint, c.ServerConfig.TokenEndpoint)
 	return nil
 }

--- a/authorization_code.go
+++ b/authorization_code.go
@@ -9,11 +9,12 @@ type AuthorizationCodeFlow struct {
 type AuthorizationCodeFlowConfig struct {
 	Scopes      string
 	CallbackURI string
+	PKCE		bool
 }
 
 func (c *AuthorizationCodeFlow) Run() error {
 	c.ServerConfig.DiscoverEndpoints()
 
-	HandleOpenIDFlow(c.ClientConfig.ClientID, c.ClientConfig.ClientSecret, c.FlowConfig.Scopes, "http://localhost:9555/callback", c.ServerConfig.DiscoveryEndpoint, c.ServerConfig.AuthorizationEndpoint, c.ServerConfig.TokenEndpoint)
+	HandleOpenIDFlow(c.ClientConfig.ClientID, c.ClientConfig.ClientSecret, c.FlowConfig.Scopes, "http://localhost:9555/callback", c.ServerConfig.DiscoveryEndpoint, c.ServerConfig.AuthorizationEndpoint, c.ServerConfig.TokenEndpoint, c.FlowConfig.PKCE)
 	return nil
 }

--- a/client_credentials.go
+++ b/client_credentials.go
@@ -14,14 +14,9 @@ type ClientCredentialsFlow struct {
 	ClientConfig *ClientConfig
 }
 
-func NewClientCredentialsFlow(serverConf *ServerConfig, clientConf *ClientConfig) *ClientCredentialsFlow {
-	return &ClientCredentialsFlow {
-		ServerConfig: serverConf,
-		ClientConfig: clientConf,
-	}
-}
-
 func (c *ClientCredentialsFlow) Run() error {
+	c.ServerConfig.DiscoverEndpoints()
+
 	vals := url.Values{}
 	vals.Set("grant_type", "client_credentials")
 	vals.Set("client_id", c.ClientConfig.ClientID)

--- a/cmd/authorization_code_cfg.go
+++ b/cmd/authorization_code_cfg.go
@@ -24,6 +24,7 @@ func parseAuthorizationCodeFlags(name string, args []string) (runner CommandRunn
 	var flowConf oidc.AuthorizationCodeFlowConfig
 	flags.StringVar(&flowConf.Scopes, "scopes", "openid", "set scopes as a space separated list")
 	flags.StringVar(&flowConf.CallbackURI, "callback-uri", "http://localhost:9555/callback", "set OIDC callback uri")
+	flags.BoolVar(&flowConf.PKCE, "pkce", false, "Enable proof-key for code exchange (PKCE)")
 
 	runner = &oidc.AuthorizationCodeFlow{
 		ServerConfig: &serverConf,
@@ -45,8 +46,8 @@ func parseAuthorizationCodeFlags(name string, args []string) (runner CommandRunn
 			"client-id is required",
 		},
 		{
-			(clientConf.ClientSecret == ""),
-			"client-secret is required",
+			(clientConf.ClientSecret == "" && !flowConf.PKCE),
+			"client-secret is required unless using PKCE",
 		},
 		{
 			(flowConf.Scopes == ""),

--- a/cmd/authorization_code_cfg_test.go
+++ b/cmd/authorization_code_cfg_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	oidc "github.com/jentz/vigilant-dollop"
+)
+
+func TestParseAuthorizationCodeFlagsCorrect(t *testing.T) {
+	
+	var tests = []struct {
+		name string
+		args []string
+		serverConf oidc.ServerConfig
+		clientConf oidc.ClientConfig
+		scopes string
+		callbackURI string
+	}{
+		{
+			"all flags",
+			[]string{
+				"--discovery-url", "https://example.com/.well-known/openid-configuration",
+				"--authorization-url", "https://example.com/authorize",
+				"--token-url", "https://example.com/token",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+				"--scopes", "openid profile email",
+				"--callback-uri", "http://localhost:8080/callback",
+			},
+			oidc.ServerConfig{
+				DiscoveryEndpoint: "https://example.com/.well-known/openid-configuration",
+				AuthorizationEndpoint: "https://example.com/authorize",
+				TokenEndpoint: "https://example.com/token",
+			},
+			oidc.ClientConfig{
+				ClientID: "client-id",
+				ClientSecret: "client-secret",
+			},
+			"openid profile email",
+			"http://localhost:8080/callback",
+		},
+		{
+			"only discovery-url",
+			[]string{
+				"--discovery-url", "https://example.com/.well-known/openid-configuration",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+				"--scopes", "openid profile email",
+				"--callback-uri", "http://localhost:8080/callback",
+			},
+			oidc.ServerConfig{
+				DiscoveryEndpoint: "https://example.com/.well-known/openid-configuration",
+				AuthorizationEndpoint: "",
+				TokenEndpoint: "",
+			},
+			oidc.ClientConfig{
+				ClientID: "client-id",
+				ClientSecret: "client-secret",
+			},
+			"openid profile email",
+			"http://localhost:8080/callback",
+		},
+		{
+			"no scopes provided",
+			[]string{
+				"--discovery-url", "https://example.com/.well-known/openid-configuration",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+				"--callback-uri", "http://localhost:8080/callback",
+			},
+			oidc.ServerConfig{
+				DiscoveryEndpoint: "https://example.com/.well-known/openid-configuration",
+				AuthorizationEndpoint: "",
+				TokenEndpoint: "",
+			},
+			oidc.ClientConfig{
+				ClientID: "client-id",
+				ClientSecret: "client-secret",
+			},
+			"openid",
+			"http://localhost:8080/callback",
+		},
+		{
+			"no callback-uri provided",
+			[]string{
+				"--discovery-url", "https://example.com/.well-known/openid-configuration",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+				"--scopes", "openid profile email",
+			},
+			oidc.ServerConfig{
+				DiscoveryEndpoint: "https://example.com/.well-known/openid-configuration",
+				AuthorizationEndpoint: "",
+				TokenEndpoint: "",
+			},
+			oidc.ClientConfig{
+				ClientID: "client-id",
+				ClientSecret: "client-secret",
+			},
+			"openid profile email",
+			"http://localhost:9555/callback",
+		},
+	}
+		
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner, output, err := parseAuthorizationCodeFlags("authorization_code", tt.args)
+			if err != nil {
+				t.Errorf("err got %v, want nil", err)
+			}
+			if output != "" {
+				t.Errorf("output got %q, want empty", output)
+			}
+			f, ok := runner.(*oidc.AuthorizationCodeFlow)
+			if !ok {
+				t.Errorf("unexpected runner type: %T", runner)
+			}
+			if !reflect.DeepEqual(*f.ServerConfig, tt.serverConf) {
+				t.Errorf("ServerConfig got %+v, want %+v", *f.ServerConfig, tt.serverConf)
+			}
+			if !reflect.DeepEqual(*f.ClientConfig, tt.clientConf) {
+				t.Errorf("ClientConfig got %+v, want %+v", *f.ClientConfig, tt.clientConf)
+			}
+			if f.FlowConfig.Scopes != tt.scopes {
+				t.Errorf("Scopes got %q, want %q", f.FlowConfig.Scopes, tt.scopes)
+			}
+			if f.FlowConfig.CallbackURI != tt.callbackURI {
+				t.Errorf("CallbackURI got %q, want %q", f.FlowConfig.CallbackURI, tt.callbackURI)
+			}
+		})
+	}
+}
+
+func TestParseAuthorizationCodeFlagsError(t *testing.T) {
+	
+	var tests = []struct {
+		name string
+		args []string
+	}{
+		{
+			"missing discovery-url, authorization-url and token-url",
+			[]string{
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+				"--scopes", "openid profile email",
+				"--callback-uri", "http://localhost:8080/callback",
+			},
+		},
+		{
+			"missing client-secret",
+			[]string{
+				"--discovery-url", "https://example.com/.well-known/openid-configuration",
+				"--client-id", "client-id",
+				"--scopes", "openid profile email",
+				"--callback-uri", "http://localhost:8080/callback",
+			},
+		},
+	}
+		
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, output, err := parseAuthorizationCodeFlags("authorization_code", tt.args)
+			if err == nil {
+				t.Errorf("err got nil, want error")
+			}
+			if output == "" {
+				t.Errorf("output got empty, want error message")
+			}
+		})
+	}
+}

--- a/cmd/client_credentials_cfg_test.go
+++ b/cmd/client_credentials_cfg_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	oidc "github.com/jentz/vigilant-dollop"
+)
+
+func TestParseClientCredentialsFlagsCorrect(t *testing.T) {
+	
+	var tests = []struct {
+		name string
+		args []string
+		serverConf oidc.ServerConfig
+		clientConf oidc.ClientConfig
+	}{
+		{
+			"all flags",
+			[]string{
+				"--discovery-url", "https://example.com/.well-known/openid-configuration",
+				"--token-url", "https://example.com/token",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+			},
+			oidc.ServerConfig{
+				DiscoveryEndpoint: "https://example.com/.well-known/openid-configuration",
+				TokenEndpoint: "https://example.com/token",
+			},
+			oidc.ClientConfig{
+				ClientID: "client-id",
+				ClientSecret: "client-secret",
+			},
+		},
+		{
+			"only discovery-url",
+			[]string{
+				"--discovery-url", "https://example.com/.well-known/openid-configuration",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+			},
+			oidc.ServerConfig{
+				DiscoveryEndpoint: "https://example.com/.well-known/openid-configuration",
+				AuthorizationEndpoint: "",
+				TokenEndpoint: "",
+			},
+			oidc.ClientConfig{
+				ClientID: "client-id",
+				ClientSecret: "client-secret",
+			},
+		},
+		{
+			"no scopes provided",
+			[]string{
+				"--discovery-url", "https://example.com/.well-known/openid-configuration",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+			},
+			oidc.ServerConfig{
+				DiscoveryEndpoint: "https://example.com/.well-known/openid-configuration",
+				AuthorizationEndpoint: "",
+				TokenEndpoint: "",
+			},
+			oidc.ClientConfig{
+				ClientID: "client-id",
+				ClientSecret: "client-secret",
+			},
+		},
+	}
+		
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner, output, err := parseClientCredentialsFlags("client_credentials", tt.args)
+			if err != nil {
+				t.Errorf("err got %v, want nil", err)
+			}
+			if output != "" {
+				t.Errorf("output got %q, want empty", output)
+			}
+			f, ok := runner.(*oidc.ClientCredentialsFlow)
+			if !ok {
+				t.Errorf("unexpected runner type: %T", runner)
+			}
+			if !reflect.DeepEqual(*f.ServerConfig, tt.serverConf) {
+				t.Errorf("ServerConfig got %+v, want %+v", *f.ServerConfig, tt.serverConf)
+			}
+			if !reflect.DeepEqual(*f.ClientConfig, tt.clientConf) {
+				t.Errorf("ClientConfig got %+v, want %+v", *f.ClientConfig, tt.clientConf)
+			}
+		})
+	}
+}
+
+func TestParseClientCredentialsFlagsError(t *testing.T) {
+	
+	var tests = []struct {
+		name string
+		args []string
+	}{
+		{
+			"missing discovery-url, authorization-url and token-url",
+			[]string{
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+			},
+		},
+		{
+			"missing client-secret",
+			[]string{
+				"--discovery-url", "https://example.com/.well-known/openid-configuration",
+				"--client-id", "client-id",
+			},
+		},
+	}
+		
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, output, err := parseClientCredentialsFlags("client_credentials", tt.args)
+			if err == nil {
+				t.Errorf("err got nil, want error")
+			}
+			if output == "" {
+				t.Errorf("output got empty, want error message")
+			}
+		})
+	}
+}

--- a/cmd/client_credentials_cfg_test.go
+++ b/cmd/client_credentials_cfg_test.go
@@ -7,7 +7,7 @@ import (
 	oidc "github.com/jentz/vigilant-dollop"
 )
 
-func TestParseClientCredentialsFlagsCorrect(t *testing.T) {
+func TestParseClientCredentialsFlagsResult(t *testing.T) {
 	
 	var tests = []struct {
 		name string


### PR DESCRIPTION
This adds a command-line argument --pkce to the authorization_code command. When provided it will create a code_verifier and code_challenge and add these to the respective calls to the authorization server. 

Providing --pkce without providing --client-secret is considered valid.