### PR TITLE
adds pkce support to authorization_code flow

### DIFF
--- a/authorization_code.go
+++ b/authorization_code.go
@@ -9,11 +9,12 @@ type AuthorizationCodeFlow struct {
 type AuthorizationCodeFlowConfig struct {
 	Scopes      string
 	CallbackURI string
+	PKCE		bool
 }
 
 func (c *AuthorizationCodeFlow) Run() error {
 	c.ServerConfig.DiscoverEndpoints()
 
-	HandleOpenIDFlow(c.ClientConfig.ClientID, c.ClientConfig.ClientSecret, c.FlowConfig.Scopes, "http://localhost:9555/callback", c.ServerConfig.DiscoveryEndpoint, c.ServerConfig.AuthorizationEndpoint, c.ServerConfig.TokenEndpoint)
+	HandleOpenIDFlow(c.ClientConfig.ClientID, c.ClientConfig.ClientSecret, c.FlowConfig.Scopes, "http://localhost:9555/callback", c.ServerConfig.DiscoveryEndpoint, c.ServerConfig.AuthorizationEndpoint, c.ServerConfig.TokenEndpoint, c.FlowConfig.PKCE)
 	return nil
 }

--- a/cmd/authorization_code_cfg.go
+++ b/cmd/authorization_code_cfg.go
@@ -24,6 +24,7 @@ func parseAuthorizationCodeFlags(name string, args []string) (runner CommandRunn
 	var flowConf oidc.AuthorizationCodeFlowConfig
 	flags.StringVar(&flowConf.Scopes, "scopes", "openid", "set scopes as a space separated list")
 	flags.StringVar(&flowConf.CallbackURI, "callback-uri", "http://localhost:9555/callback", "set OIDC callback uri")
+	flags.BoolVar(&flowConf.PKCE, "pkce", false, "Enable proof-key for code exchange (PKCE)")
 
 	runner = &oidc.AuthorizationCodeFlow{
 		ServerConfig: &serverConf,
@@ -45,8 +46,8 @@ func parseAuthorizationCodeFlags(name string, args []string) (runner CommandRunn
 			"client-id is required",
 		},
 		{
-			(clientConf.ClientSecret == ""),
-			"client-secret is required",
+			(clientConf.ClientSecret == "" && !flowConf.PKCE),
+			"client-secret is required unless using PKCE",
 		},
 		{
 			(flowConf.Scopes == ""),

--- a/cmd/client_credentials_cfg_test.go
+++ b/cmd/client_credentials_cfg_test.go
@@ -7,7 +7,7 @@ import (
 	oidc "github.com/jentz/vigilant-dollop"
 )
 
-func TestParseClientCredentialsFlagsCorrect(t *testing.T) {
+func TestParseClientCredentialsFlagsResult(t *testing.T) {
 	
 	var tests = []struct {
 		name string

--- a/oidc.go
+++ b/oidc.go
@@ -2,10 +2,14 @@ package oidc
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/sha256"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log"
+	"math/big"
 	"net/http"
 	"net/url"
 	"os"
@@ -34,7 +38,33 @@ func (h *callbackEndpoint) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	h.shutdownSignal <- "shutdown"
 }
 
-func HandleOpenIDFlow(clientID, clientSecret, scopes, callbackURL, discoveryEndpoint, authorizationEndpoint, tokenEndpoint string) {
+func randomInt(min, max int) int {
+	nBig, err := rand.Int(rand.Reader, big.NewInt(int64(max-min)))
+    if err != nil {
+        panic(err)
+    }
+    return int(nBig.Int64()) + min
+}
+
+func generateCodeVerifier(n int) string {
+	if n < 32 || n > 96 {
+		panic("Code verifier length before base64 encoding must be between 32 and 96 bytes")
+	}
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		panic(err)
+	}
+	// NoPadding is used to avoid '=' padding characters which are not accepted by the authorization server in the code_verifier parameter
+	return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(b)
+}
+
+func calculateCodeChallenge(codeVerifier string) string {
+	sha := sha256.Sum256([]byte(codeVerifier))
+	return base64.RawURLEncoding.EncodeToString(sha[:])
+}
+
+func HandleOpenIDFlow(clientID, clientSecret, scopes, callbackURL, discoveryEndpoint, authorizationEndpoint, tokenEndpoint string, usePKCE bool) {
 
 	callbackEndpoint := &callbackEndpoint{}
 	callbackEndpoint.shutdownSignal = make(chan string)
@@ -68,6 +98,17 @@ func HandleOpenIDFlow(clientID, clientSecret, scopes, callbackURL, discoveryEndp
 	query.Set("response_type", "code")
 	query.Set("scope", scopes)
 	query.Set("redirect_uri", callbackURL)
+
+	var codeVerifier string
+	if usePKCE {
+		// Starting with a byte array of 32-96 bytes ensures that the base64 encoded string will be between 43 and 128 characters long as required by RFC7636
+		codeVerifier = generateCodeVerifier(randomInt(32, 96))
+		codeChallenge := calculateCodeChallenge(codeVerifier)
+		query.Set("code_challenge_method", "S256")
+		query.Set("code_challenge", codeChallenge)
+	}
+	log.Printf("codeVerifier: %s\n", codeVerifier)
+
 	authURL.RawQuery = query.Encode()
 
 	fmt.Fprintf(os.Stderr, "authURL is %s\n", authURL.String())
@@ -96,6 +137,9 @@ func HandleOpenIDFlow(clientID, clientSecret, scopes, callbackURL, discoveryEndp
 	vals.Set("grant_type", "authorization_code")
 	vals.Set("code", callbackEndpoint.code)
 	vals.Set("redirect_uri", callbackURL)
+	if usePKCE {
+		vals.Set("code_verifier", codeVerifier)
+	}
 	req, err := http.NewRequest("POST", tokenEndpoint, strings.NewReader(vals.Encode()))
 	if err != nil {
 		log.Fatal(err)

--- a/oidc_test.go
+++ b/oidc_test.go
@@ -1,0 +1,35 @@
+package oidc
+
+import (
+	"testing"
+)
+
+func TestGenerateCodeVerifier(t *testing.T) {
+	var tests = []struct {
+		name string
+		generateBytes int
+		wantBytes int
+		wantPanic bool
+	}{
+		{ "24 bytes random, string too short", 24, 32, true },
+		{ "32 bytes random, 43 bytes string", 32, 43, false },
+		{ "64 bytes random, 86 bytes string", 64, 86, false },
+		{ "96 bytes random, 128 bytes string", 96, 128, false },
+		{ "128 bytes random, string too long", 128, 152, true },
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+            defer func() {
+                r := recover()
+                if (r != nil) != tt.wantPanic {
+                    t.Errorf("generateCodeVerifier() recover = %v, wantPanic = %v", r, tt.wantPanic)
+                }
+            }()
+			gotBytes := len(generateCodeVerifier(tt.generateBytes))
+			if gotBytes != tt.wantBytes {
+				t.Errorf("err got %v, want %v", gotBytes, tt.wantBytes)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds a command-line argument --pkce to the authorization_code command. When provided it will create a code_verifier and code_challenge and add these to the respective calls to the authorization server.

Providing --pkce without providing --client-secret is considered valid.