### PR TITLE
adds custom arguments for authorization_code

### DIFF
--- a/authorization_code.go
+++ b/authorization_code.go
@@ -8,12 +8,13 @@ type AuthorizationCodeFlow struct {
 type AuthorizationCodeFlowConfig struct {
 	Scopes      string
 	CallbackURI string
-	PKCE        bool
+	CustomArgs  CustomArgs
+	PKCE		bool
 }
 
 func (c *AuthorizationCodeFlow) Run() error {
 	c.Config.DiscoverEndpoints()
 
-	HandleOpenIDFlow(c.Config.ClientID, c.Config.ClientSecret, c.FlowConfig.Scopes, "http://localhost:9555/callback", c.Config.DiscoveryEndpoint, c.Config.AuthorizationEndpoint, c.Config.TokenEndpoint, c.FlowConfig.PKCE)
+	HandleOpenIDFlow(c.Config.ClientID, c.Config.ClientSecret, c.FlowConfig.Scopes, "http://localhost:9555/callback", c.Config.DiscoveryEndpoint, c.Config.AuthorizationEndpoint, c.Config.TokenEndpoint, c.FlowConfig.CustomArgs, c.FlowConfig.PKCE)
 	return nil
 }

--- a/cmd/authorization_code_cfg.go
+++ b/cmd/authorization_code_cfg.go
@@ -23,6 +23,7 @@ func parseAuthorizationCodeFlags(name string, args []string) (runner CommandRunn
 	var flowConf oidc.AuthorizationCodeFlowConfig
 	flags.StringVar(&flowConf.Scopes, "scopes", "openid", "set scopes as a space separated list")
 	flags.StringVar(&flowConf.CallbackURI, "callback-uri", "http://localhost:9555/callback", "set OIDC callback uri")
+	flags.Var(&flowConf.CustomArgs, "custom", "custom authorization parameters (e.g. prompt=login), argument can be given multiple times")
 	flags.BoolVar(&flowConf.PKCE, "pkce", false, "use proof-key for code exchange (PKCE)")
 
 	runner = &oidc.AuthorizationCodeFlow{

--- a/oidc.go
+++ b/oidc.go
@@ -64,7 +64,7 @@ func calculateCodeChallenge(codeVerifier string) string {
 	return base64.RawURLEncoding.EncodeToString(sha[:])
 }
 
-func HandleOpenIDFlow(clientID, clientSecret, scopes, callbackURL, discoveryEndpoint, authorizationEndpoint, tokenEndpoint string, usePKCE bool) {
+func HandleOpenIDFlow(clientID, clientSecret, scopes, callbackURL, discoveryEndpoint, authorizationEndpoint, tokenEndpoint string, customArgs CustomArgs, usePKCE bool) {
 
 	callbackEndpoint := &callbackEndpoint{}
 	callbackEndpoint.shutdownSignal = make(chan string)
@@ -98,6 +98,11 @@ func HandleOpenIDFlow(clientID, clientSecret, scopes, callbackURL, discoveryEndp
 	query.Set("response_type", "code")
 	query.Set("scope", scopes)
 	query.Set("redirect_uri", callbackURL)
+
+	for _, arg := range customArgs {
+		kv := strings.SplitN(arg, "=", 2)
+		query.Set(kv[0], kv[1])
+	}
 
 	var codeVerifier string
 	if usePKCE {

--- a/oidc_config.go
+++ b/oidc_config.go
@@ -36,3 +36,14 @@ func (c *Config) DiscoverEndpoints() {
 	assignIfEmpty(&c.IntrospectionEndpoint, discoveryJson["introspection_endpoint"].(string))
 	assignIfEmpty(&c.UserinfoEndpoint, discoveryJson["userinfo_endpoint"].(string))
 }
+
+type CustomArgs []string
+
+func (c *CustomArgs) String() string {
+	return ""
+}
+
+func (c *CustomArgs) Set(value string) error {
+	*c = append(*c, value)
+	return nil
+}


### PR DESCRIPTION
This adds support for --custom arguments to the authorization_code flow, which enables users to provide additional arguments to the authorization request as needed.