### PR TITLE
feat: support token introspection

### DIFF
--- a/cmd/introspect_cfg.go
+++ b/cmd/introspect_cfg.go
@@ -15,7 +15,7 @@ func parseIntrospectFlags(name string, args []string) (runner CommandRunner, out
 	var oidcConf oidc.Config
 	flags.StringVar(&oidcConf.IssuerUrl, "issuer", "", "set issuer url (required)")
 	flags.StringVar(&oidcConf.DiscoveryEndpoint, "discovery-url", "", "override discovery url")
-	flags.StringVar(&oidcConf.IntrospectionEndpoint, "token-url", "", "override token url")
+	flags.StringVar(&oidcConf.IntrospectionEndpoint, "introspection-url", "", "override introspection url")
 	flags.StringVar(&oidcConf.ClientID, "client-id", "", "set client ID (required)")
 	flags.StringVar(&oidcConf.ClientSecret, "client-secret", "", "set client secret (required unless bearer token is provided)")
 
@@ -25,7 +25,7 @@ func parseIntrospectFlags(name string, args []string) (runner CommandRunner, out
 	flags.StringVar(&flowConf.TokenTypeHint, "token-type", "access_token", "token type hint (e.g. access_token")
 
 	runner = &oidc.IntrospectFlow{
-		Config: &oidcConf,
+		Config:     &oidcConf,
 		FlowConfig: &flowConf,
 	}
 
@@ -47,8 +47,8 @@ func parseIntrospectFlags(name string, args []string) (runner CommandRunner, out
 			"client-id is required",
 		},
 		{
-			(oidcConf.ClientSecret == ""),
-			"client-secret is required",
+			(oidcConf.ClientSecret == "" && flowConf.BearerToken == ""),
+			"client-secret or bearer-token is required",
 		},
 	}
 

--- a/cmd/introspect_cfg.go
+++ b/cmd/introspect_cfg.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+
+	oidc "github.com/jentz/vigilant-dollop"
+)
+
+func parseIntrospectFlags(name string, args []string) (runner CommandRunner, output string, err error) {
+	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+	var buf bytes.Buffer
+	flags.SetOutput(&buf)
+
+	var oidcConf oidc.Config
+	flags.StringVar(&oidcConf.IssuerUrl, "issuer", "", "set issuer url (required)")
+	flags.StringVar(&oidcConf.DiscoveryEndpoint, "discovery-url", "", "override discovery url")
+	flags.StringVar(&oidcConf.IntrospectionEndpoint, "token-url", "", "override token url")
+	flags.StringVar(&oidcConf.ClientID, "client-id", "", "set client ID (required)")
+	flags.StringVar(&oidcConf.ClientSecret, "client-secret", "", "set client secret (required unless bearer token is provided)")
+
+	var flowConf oidc.IntrospectFlowConfig
+	flags.StringVar(&flowConf.BearerToken, "bearer-token", "", "bearer token for authorization (required unless client secret is provided)")
+	flags.StringVar(&flowConf.Token, "token", "", "token to be introspected (required)")
+	flags.StringVar(&flowConf.TokenTypeHint, "token-type", "access_token", "token type hint (e.g. access_token")
+
+	runner = &oidc.IntrospectFlow{
+		Config: &oidcConf,
+		FlowConfig: &flowConf,
+	}
+
+	err = flags.Parse(args)
+	if err != nil {
+		return nil, buf.String(), err
+	}
+
+	var invalidArgsChecks = []struct {
+		condition bool
+		message   string
+	}{
+		{
+			(oidcConf.IssuerUrl == ""),
+			"issuer is required",
+		},
+		{
+			(oidcConf.ClientID == ""),
+			"client-id is required",
+		},
+		{
+			(oidcConf.ClientSecret == ""),
+			"client-secret is required",
+		},
+	}
+
+	for _, check := range invalidArgsChecks {
+		if check.condition {
+			return nil, check.message, flag.ErrHelp
+		}
+	}
+
+	return runner, buf.String(), nil
+}

--- a/cmd/introspect_cfg_test.go
+++ b/cmd/introspect_cfg_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	oidc "github.com/jentz/vigilant-dollop"
+)
+
+func TestParseIntrospectFlagsResult(t *testing.T) {
+	
+	var tests = []struct {
+		name string
+		args []string
+		oidcConf oidc.Config
+	}{
+		{
+			"all flags",
+			[]string{
+				"--issuer", "https://example.com",
+				"--discovery-url", "https://example.com/.well-known/openid-configuration",
+				"--token-url", "https://example.com/token",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+			},
+			oidc.Config{
+				IssuerUrl: "https://example.com",
+				DiscoveryEndpoint: "https://example.com/.well-known/openid-configuration",
+				TokenEndpoint: "https://example.com/token",
+				ClientID: "client-id",
+				ClientSecret: "client-secret",
+			},
+		},
+		{
+			"only issuer",
+			[]string{
+				"--issuer", "https://example.com",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+			},
+			oidc.Config{
+				IssuerUrl: "https://example.com",
+				DiscoveryEndpoint: "",
+				AuthorizationEndpoint: "",
+				TokenEndpoint: "",
+				ClientID: "client-id",
+				ClientSecret: "client-secret",
+			},
+		},
+		{
+			"no scopes provided",
+			[]string{
+				"--issuer", "https://example.com",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+			},
+			oidc.Config{
+				IssuerUrl: "https://example.com",
+				DiscoveryEndpoint: "",
+				AuthorizationEndpoint: "",
+				TokenEndpoint: "",
+				ClientID: "client-id",
+				ClientSecret: "client-secret",
+			},
+		},
+	}
+		
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner, output, err := parseClientCredentialsFlags("client_credentials", tt.args)
+			if err != nil {
+				t.Errorf("err got %v, want nil", err)
+			}
+			if output != "" {
+				t.Errorf("output got %q, want empty", output)
+			}
+			f, ok := runner.(*oidc.ClientCredentialsFlow)
+			if !ok {
+				t.Errorf("unexpected runner type: %T", runner)
+			}
+			if !reflect.DeepEqual(*f.Config, tt.oidcConf) {
+				t.Errorf("Config got %+v, want %+v", *f.Config, tt.oidcConf)
+			}
+		})
+	}
+}
+
+func TestParseIntrospectFlagsError(t *testing.T) {
+	
+	var tests = []struct {
+		name string
+		args []string
+	}{
+		{
+			"missing discovery-url and token-url",
+			[]string{
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+			},
+		},
+		{
+			"missing client-secret",
+			[]string{
+				"--issuer", "https://example.com",
+				"--discovery-url", "https://example.com/.well-known/openid-configuration",
+				"--client-id", "client-id",
+			},
+		},
+	}
+		
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, output, err := parseClientCredentialsFlags("client_credentials", tt.args)
+			if err == nil {
+				t.Errorf("err got nil, want error")
+			}
+			if output == "" {
+				t.Errorf("output got empty, want error message")
+			}
+		})
+	}
+}

--- a/cmd/introspect_cfg_test.go
+++ b/cmd/introspect_cfg_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 func TestParseIntrospectFlagsResult(t *testing.T) {
-	
+
 	var tests = []struct {
-		name string
-		args []string
+		name     string
+		args     []string
 		oidcConf oidc.Config
 	}{
 		{
@@ -19,16 +19,16 @@ func TestParseIntrospectFlagsResult(t *testing.T) {
 			[]string{
 				"--issuer", "https://example.com",
 				"--discovery-url", "https://example.com/.well-known/openid-configuration",
-				"--token-url", "https://example.com/token",
+				"--introspection-url", "https://example.com/introspection",
 				"--client-id", "client-id",
 				"--client-secret", "client-secret",
 			},
 			oidc.Config{
-				IssuerUrl: "https://example.com",
-				DiscoveryEndpoint: "https://example.com/.well-known/openid-configuration",
-				TokenEndpoint: "https://example.com/token",
-				ClientID: "client-id",
-				ClientSecret: "client-secret",
+				IssuerUrl:             "https://example.com",
+				DiscoveryEndpoint:     "https://example.com/.well-known/openid-configuration",
+				IntrospectionEndpoint: "https://example.com/introspection",
+				ClientID:              "client-id",
+				ClientSecret:          "client-secret",
 			},
 		},
 		{
@@ -39,12 +39,11 @@ func TestParseIntrospectFlagsResult(t *testing.T) {
 				"--client-secret", "client-secret",
 			},
 			oidc.Config{
-				IssuerUrl: "https://example.com",
-				DiscoveryEndpoint: "",
-				AuthorizationEndpoint: "",
-				TokenEndpoint: "",
-				ClientID: "client-id",
-				ClientSecret: "client-secret",
+				IssuerUrl:             "https://example.com",
+				DiscoveryEndpoint:     "",
+				IntrospectionEndpoint: "",
+				ClientID:              "client-id",
+				ClientSecret:          "client-secret",
 			},
 		},
 		{
@@ -55,26 +54,25 @@ func TestParseIntrospectFlagsResult(t *testing.T) {
 				"--client-secret", "client-secret",
 			},
 			oidc.Config{
-				IssuerUrl: "https://example.com",
-				DiscoveryEndpoint: "",
-				AuthorizationEndpoint: "",
-				TokenEndpoint: "",
-				ClientID: "client-id",
-				ClientSecret: "client-secret",
+				IssuerUrl:             "https://example.com",
+				DiscoveryEndpoint:     "",
+				IntrospectionEndpoint: "",
+				ClientID:              "client-id",
+				ClientSecret:          "client-secret",
 			},
 		},
 	}
-		
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runner, output, err := parseClientCredentialsFlags("client_credentials", tt.args)
+			runner, output, err := parseIntrospectFlags("introspect", tt.args)
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
 			if output != "" {
 				t.Errorf("output got %q, want empty", output)
 			}
-			f, ok := runner.(*oidc.ClientCredentialsFlow)
+			f, ok := runner.(*oidc.IntrospectFlow)
 			if !ok {
 				t.Errorf("unexpected runner type: %T", runner)
 			}
@@ -86,13 +84,13 @@ func TestParseIntrospectFlagsResult(t *testing.T) {
 }
 
 func TestParseIntrospectFlagsError(t *testing.T) {
-	
+
 	var tests = []struct {
 		name string
 		args []string
 	}{
 		{
-			"missing discovery-url and token-url",
+			"missing issuer",
 			[]string{
 				"--client-id", "client-id",
 				"--client-secret", "client-secret",
@@ -107,10 +105,10 @@ func TestParseIntrospectFlagsError(t *testing.T) {
 			},
 		},
 	}
-		
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, output, err := parseClientCredentialsFlags("client_credentials", tt.args)
+			_, output, err := parseIntrospectFlags("introspect", tt.args)
 			if err == nil {
 				t.Errorf("err got nil, want error")
 			}

--- a/cmd/oidc-cli.go
+++ b/cmd/oidc-cli.go
@@ -21,6 +21,7 @@ type Command struct {
 var commands = []Command{
 	{Name: "authorization_code", Help: "Uses the authorization code flow to get a token response", Configure: parseAuthorizationCodeFlags},
 	{Name: "client_credentials", Help: "Uses the client credentials flow to get a token response", Configure: parseClientCredentialsFlags},
+	{Name: "introspect", Help: "Uses the introspection flow to validate a token and fetch the associated claims", Configure: parseIntrospectFlags},
 	{Name: "help", Help: "Prints help"},
 }
 

--- a/introspect.go
+++ b/introspect.go
@@ -8,8 +8,8 @@ type IntrospectFlow struct {
 }
 
 type IntrospectFlowConfig struct {
-	BearerToken	  string
-	Token		  string
+	BearerToken   string
+	Token         string
 	TokenTypeHint string
 }
 
@@ -17,16 +17,16 @@ func (c *IntrospectFlow) Run() error {
 	c.Config.DiscoverEndpoints()
 
 	req := IntrospectionRequest{
-		Endpoint: 		  c.Config.IntrospectionEndpoint,
-		ClientID: 		  c.Config.ClientID,
-		ClientSecret: 	  c.Config.ClientSecret,
-		Token: 			  c.FlowConfig.Token,
-		TokenTypeHint: 	  c.FlowConfig.TokenTypeHint,
-		BearerToken: 	  c.FlowConfig.BearerToken,
+		Endpoint:      c.Config.IntrospectionEndpoint,
+		ClientID:      c.Config.ClientID,
+		ClientSecret:  c.Config.ClientSecret,
+		Token:         c.FlowConfig.Token,
+		TokenTypeHint: c.FlowConfig.TokenTypeHint,
+		BearerToken:   c.FlowConfig.BearerToken,
 	}
 
 	resp, err := req.Execute()
-	if (err != nil) {
+	if err != nil {
 		return err
 	}
 
@@ -35,5 +35,5 @@ func (c *IntrospectFlow) Run() error {
 		return err
 	}
 	fmt.Println(jsonStr)
-	return nil	
+	return nil
 }

--- a/introspect.go
+++ b/introspect.go
@@ -1,0 +1,39 @@
+package oidc
+
+import "fmt"
+
+type IntrospectFlow struct {
+	Config     *Config
+	FlowConfig *IntrospectFlowConfig
+}
+
+type IntrospectFlowConfig struct {
+	BearerToken	  string
+	Token		  string
+	TokenTypeHint string
+}
+
+func (c *IntrospectFlow) Run() error {
+	c.Config.DiscoverEndpoints()
+
+	req := IntrospectionRequest{
+		Endpoint: 		  c.Config.IntrospectionEndpoint,
+		ClientID: 		  c.Config.ClientID,
+		ClientSecret: 	  c.Config.ClientSecret,
+		Token: 			  c.FlowConfig.Token,
+		TokenTypeHint: 	  c.FlowConfig.TokenTypeHint,
+		BearerToken: 	  c.FlowConfig.BearerToken,
+	}
+
+	resp, err := req.Execute()
+	if (err != nil) {
+		return err
+	}
+
+	jsonStr, err := resp.JSON()
+	if err != nil {
+		return err
+	}
+	fmt.Println(jsonStr)
+	return nil	
+}

--- a/introspection_request.go
+++ b/introspection_request.go
@@ -1,0 +1,46 @@
+package oidc
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type IntrospectionRequest struct {
+	Endpoint 	  string
+	Token 		  string
+	TokenTypeHint string
+	ClientID      string
+	ClientSecret  string
+	BearerToken   string
+}
+
+func (tReq *IntrospectionRequest) Execute() (tResp *IntrospectionResponse, err error) {
+	vals := url.Values{}
+	vals.Set("token", tReq.Token)
+	vals.Set("token_type_hint", tReq.TokenTypeHint)
+
+	req, err := http.NewRequest("POST", tReq.Endpoint, strings.NewReader(vals.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(tReq.ClientID, tReq.ClientSecret)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New("token introspection request failed: " + resp.Status)
+	}
+	defer resp.Body.Close()
+	dec := json.NewDecoder(resp.Body)
+	err = dec.Decode(&tResp)
+	if err != nil {
+		return nil, errors.New("failed to parse token response")
+	}
+
+	return tResp, nil
+}

--- a/introspection_request.go
+++ b/introspection_request.go
@@ -9,8 +9,8 @@ import (
 )
 
 type IntrospectionRequest struct {
-	Endpoint 	  string
-	Token 		  string
+	Endpoint      string
+	Token         string
 	TokenTypeHint string
 	ClientID      string
 	ClientSecret  string
@@ -39,7 +39,7 @@ func (tReq *IntrospectionRequest) Execute() (tResp *IntrospectionResponse, err e
 	dec := json.NewDecoder(resp.Body)
 	err = dec.Decode(&tResp)
 	if err != nil {
-		return nil, errors.New("failed to parse token response")
+		return nil, errors.New("failed to parse introspection response")
 	}
 
 	return tResp, nil

--- a/introspection_response.go
+++ b/introspection_response.go
@@ -1,0 +1,41 @@
+package oidc
+
+import (
+	"encoding/json"
+)
+
+type IntrospectionResponse struct {
+	Active				bool   `json:"active"`
+	Scope				string `json:"scope,omitempty"`
+	ClientID			string `json:"client_id,omitempty"`
+	Username			string `json:"username,omitempty"`
+	TokenType			string `json:"token_type,omitempty"`
+	Exp					int    `json:"exp,omitempty"`
+	Iat					int    `json:"iat,omitempty"`
+	Nbf					int    `json:"nbf,omitempty"`
+	Sub					string `json:"sub,omitempty"`
+	Azp					string `json:"azp,omitempty"`
+	Aud					string `json:"aud,omitempty"`
+	Jti					string `json:"jti,omitempty"`
+	Email				string `json:"email,omitempty"`
+	EmailVerified		bool   `json:"email_verified,omitempty"`
+	Phone				string `json:"phone,omitempty"`
+	PhoneVerified		bool   `json:"phone_verified,omitempty"`
+	Address				string `json:"address,omitempty"`
+	UpdatedAt			int    `json:"updated_at,omitempty"`
+	AuthTime			int    `json:"auth_time,omitempty"`
+	Nonce				string `json:"nonce,omitempty"`
+	Amr					string `json:"amr,omitempty"`
+	ACR					string `json:"acr,omitempty"`
+	AzpClientID			string `json:"azp_client_id,omitempty"`
+	RealmAccess			string `json:"realm_access,omitempty"`
+	ResourceAccess		string `json:"resource_access,omitempty"`
+}
+
+func (tResp *IntrospectionResponse) JSON() (string, error) {
+	jsonStr, err := json.Marshal(&tResp)
+	if err != nil {
+		return "", err
+	}
+	return string(jsonStr), nil
+}

--- a/introspection_response.go
+++ b/introspection_response.go
@@ -5,31 +5,31 @@ import (
 )
 
 type IntrospectionResponse struct {
-	Active				bool   `json:"active"`
-	Scope				string `json:"scope,omitempty"`
-	ClientID			string `json:"client_id,omitempty"`
-	Username			string `json:"username,omitempty"`
-	TokenType			string `json:"token_type,omitempty"`
-	Exp					int    `json:"exp,omitempty"`
-	Iat					int    `json:"iat,omitempty"`
-	Nbf					int    `json:"nbf,omitempty"`
-	Sub					string `json:"sub,omitempty"`
-	Azp					string `json:"azp,omitempty"`
-	Aud					string `json:"aud,omitempty"`
-	Jti					string `json:"jti,omitempty"`
-	Email				string `json:"email,omitempty"`
-	EmailVerified		bool   `json:"email_verified,omitempty"`
-	Phone				string `json:"phone,omitempty"`
-	PhoneVerified		bool   `json:"phone_verified,omitempty"`
-	Address				string `json:"address,omitempty"`
-	UpdatedAt			int    `json:"updated_at,omitempty"`
-	AuthTime			int    `json:"auth_time,omitempty"`
-	Nonce				string `json:"nonce,omitempty"`
-	Amr					string `json:"amr,omitempty"`
-	ACR					string `json:"acr,omitempty"`
-	AzpClientID			string `json:"azp_client_id,omitempty"`
-	RealmAccess			string `json:"realm_access,omitempty"`
-	ResourceAccess		string `json:"resource_access,omitempty"`
+	Active         bool   `json:"active"`
+	Scope          string `json:"scope,omitempty"`
+	ClientID       string `json:"client_id,omitempty"`
+	Username       string `json:"username,omitempty"`
+	TokenType      string `json:"token_type,omitempty"`
+	Exp            int    `json:"exp,omitempty"`
+	Iat            int    `json:"iat,omitempty"`
+	Nbf            int    `json:"nbf,omitempty"`
+	Sub            string `json:"sub,omitempty"`
+	Azp            string `json:"azp,omitempty"`
+	Aud            string `json:"aud,omitempty"`
+	Jti            string `json:"jti,omitempty"`
+	Email          string `json:"email,omitempty"`
+	EmailVerified  bool   `json:"email_verified,omitempty"`
+	Phone          string `json:"phone,omitempty"`
+	PhoneVerified  bool   `json:"phone_verified,omitempty"`
+	Address        string `json:"address,omitempty"`
+	UpdatedAt      int    `json:"updated_at,omitempty"`
+	AuthTime       int    `json:"auth_time,omitempty"`
+	Nonce          string `json:"nonce,omitempty"`
+	Amr            string `json:"amr,omitempty"`
+	ACR            string `json:"acr,omitempty"`
+	AzpClientID    string `json:"azp_client_id,omitempty"`
+	RealmAccess    string `json:"realm_access,omitempty"`
+	ResourceAccess string `json:"resource_access,omitempty"`
 }
 
 func (tResp *IntrospectionResponse) JSON() (string, error) {


### PR DESCRIPTION
Adds foundational support for token introspection as a new subcommand. Allows passing a token on the command-line and outputs the parsed response.

Accepts the following arguments:
```
❯ ./oidc-cli introspect -h
Usage of introspect:
  -bearer-token string
        bearer token for authorization (required unless client secret is provided)
  -client-id string
        set client ID (required)
  -client-secret string
        set client secret (required unless bearer token is provided)
  -discovery-url string
        override discovery url
  -issuer string
        set issuer url (required)
  -token string
        token to be introspected (required)
  -token-type string
        token type hint (e.g. access_token (default "access_token")
  -token-url string
        override token url
```

Known limitations:
* limited error handling
* missing tests
* non-standard claims in introspection responses are not mapped
* does not support reading the token from stdin yet
* does not support using bearer-token for authorization yet