### PR TITLE
supports scopes in client_cred flow

### DIFF
--- a/client_credentials.go
+++ b/client_credentials.go
@@ -5,7 +5,12 @@ import (
 )
 
 type ClientCredentialsFlow struct {
-	Config *Config
+	Config     *Config
+	FlowConfig *ClientCredentialsFlowConfig
+}
+
+type ClientCredentialsFlowConfig struct {
+	Scopes string
 }
 
 func (c *ClientCredentialsFlow) Run() error {
@@ -16,6 +21,10 @@ func (c *ClientCredentialsFlow) Run() error {
 		GrantType:    "client_credentials",
 		ClientID:     c.Config.ClientID,
 		ClientSecret: c.Config.ClientSecret,
+	}
+
+	if c.FlowConfig.Scopes != "" {
+		req.Scope = c.FlowConfig.Scopes
 	}
 
 	resp, err := req.Execute()

--- a/cmd/client_credentials_cfg.go
+++ b/cmd/client_credentials_cfg.go
@@ -19,8 +19,12 @@ func parseClientCredentialsFlags(name string, args []string) (runner CommandRunn
 	flags.StringVar(&oidcConf.ClientID, "client-id", "", "set client ID (required)")
 	flags.StringVar(&oidcConf.ClientSecret, "client-secret", "", "set client secret (required)")
 
+	var flowConf oidc.ClientCredentialsFlowConfig
+	flags.StringVar(&flowConf.Scopes, "scopes", "", "set scopes as a space separated list")
+
 	runner = &oidc.ClientCredentialsFlow{
-		Config: &oidcConf,
+		Config:     &oidcConf,
+		FlowConfig: &flowConf,
 	}
 
 	err = flags.Parse(args)

--- a/cmd/client_credentials_cfg_test.go
+++ b/cmd/client_credentials_cfg_test.go
@@ -8,11 +8,12 @@ import (
 )
 
 func TestParseClientCredentialsFlagsResult(t *testing.T) {
-	
+
 	var tests = []struct {
-		name string
-		args []string
+		name     string
+		args     []string
 		oidcConf oidc.Config
+		flowConf oidc.ClientCredentialsFlowConfig
 	}{
 		{
 			"all flags",
@@ -24,11 +25,14 @@ func TestParseClientCredentialsFlagsResult(t *testing.T) {
 				"--client-secret", "client-secret",
 			},
 			oidc.Config{
-				IssuerUrl: "https://example.com",
+				IssuerUrl:         "https://example.com",
 				DiscoveryEndpoint: "https://example.com/.well-known/openid-configuration",
-				TokenEndpoint: "https://example.com/token",
-				ClientID: "client-id",
-				ClientSecret: "client-secret",
+				TokenEndpoint:     "https://example.com/token",
+				ClientID:          "client-id",
+				ClientSecret:      "client-secret",
+			},
+			oidc.ClientCredentialsFlowConfig{
+				Scopes: "",
 			},
 		},
 		{
@@ -39,32 +43,39 @@ func TestParseClientCredentialsFlagsResult(t *testing.T) {
 				"--client-secret", "client-secret",
 			},
 			oidc.Config{
-				IssuerUrl: "https://example.com",
-				DiscoveryEndpoint: "",
+				IssuerUrl:             "https://example.com",
+				DiscoveryEndpoint:     "",
 				AuthorizationEndpoint: "",
-				TokenEndpoint: "",
-				ClientID: "client-id",
-				ClientSecret: "client-secret",
+				TokenEndpoint:         "",
+				ClientID:              "client-id",
+				ClientSecret:          "client-secret",
+			},
+			oidc.ClientCredentialsFlowConfig{
+				Scopes: "",
 			},
 		},
 		{
-			"no scopes provided",
+			"scopes provided",
 			[]string{
 				"--issuer", "https://example.com",
 				"--client-id", "client-id",
 				"--client-secret", "client-secret",
+				"--scopes", "expected",
 			},
 			oidc.Config{
-				IssuerUrl: "https://example.com",
-				DiscoveryEndpoint: "",
+				IssuerUrl:             "https://example.com",
+				DiscoveryEndpoint:     "",
 				AuthorizationEndpoint: "",
-				TokenEndpoint: "",
-				ClientID: "client-id",
-				ClientSecret: "client-secret",
+				TokenEndpoint:         "",
+				ClientID:              "client-id",
+				ClientSecret:          "client-secret",
+			},
+			oidc.ClientCredentialsFlowConfig{
+				Scopes: "expected",
 			},
 		},
 	}
-		
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			runner, output, err := parseClientCredentialsFlags("client_credentials", tt.args)
@@ -81,12 +92,15 @@ func TestParseClientCredentialsFlagsResult(t *testing.T) {
 			if !reflect.DeepEqual(*f.Config, tt.oidcConf) {
 				t.Errorf("Config got %+v, want %+v", *f.Config, tt.oidcConf)
 			}
+			if !reflect.DeepEqual(*f.FlowConfig, tt.flowConf) {
+				t.Errorf("FlowConfig got %+v, want %+v", *f.FlowConfig, tt.flowConf)
+			}
 		})
 	}
 }
 
 func TestParseClientCredentialsFlagsError(t *testing.T) {
-	
+
 	var tests = []struct {
 		name string
 		args []string
@@ -107,7 +121,7 @@ func TestParseClientCredentialsFlagsError(t *testing.T) {
 			},
 		},
 	}
-		
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, output, err := parseClientCredentialsFlags("client_credentials", tt.args)

--- a/token_request.go
+++ b/token_request.go
@@ -24,6 +24,11 @@ func (tReq *TokenRequest) Execute() (tResp *TokenResponse, err error) {
 	vals := url.Values{}
 	vals.Set("grant_type", tReq.GrantType)
 	vals.Set("client_id", tReq.ClientID)
+
+	if tReq.Scope != "" {
+		vals.Set("scope", tReq.Scope)
+	}
+
 	if tReq.GrantType == "client_credentials" {
 		vals.Set("client_secret", tReq.ClientSecret)
 	} else {


### PR DESCRIPTION
Adds support for the scope parameter in the client credential flow allowing the relying party to request scopes for their token.