### PR TITLE
feat: allows the user to customize the callback url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ oidc-cli*
 
 # goreleaser dist directory
 dist/
+
+# asdf
+.tool-versions

--- a/authorization_request.go
+++ b/authorization_request.go
@@ -28,7 +28,11 @@ type AuthorizationRequest struct {
 func (aReq *AuthorizationRequest) Execute(authEndpoint string, customArgs ...string) (aResp *AuthorizationResponse, err error) {
 
 	callbackEndpoint := &callbackEndpoint{}
-	callbackEndpoint.start()
+	callbackURL, err := url.Parse(aReq.RedirectURI)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to parse redirect uri %s because %v\n", aReq.RedirectURI, err)
+	}
+	callbackEndpoint.start(callbackURL.Host, callbackURL.Path)
 
 	authURL, err := url.Parse(authEndpoint)
 	if err != nil {
@@ -65,6 +69,6 @@ func (aReq *AuthorizationRequest) Execute(authEndpoint string, customArgs ...str
 		aResp.Code = callbackEndpoint.code
 		return aResp, nil
 	} else {
-		return nil, fmt.Errorf("authorization failed with error %s and description %s", callbackEndpoint.errorMsg, callbackEndpoint.errorDescription)
+		return nil, fmt.Errorf("authorization failed with error %s and description %s\n", callbackEndpoint.errorMsg, callbackEndpoint.errorDescription)
 	}
 }

--- a/authorization_request.go
+++ b/authorization_request.go
@@ -31,6 +31,7 @@ func (aReq *AuthorizationRequest) Execute(authEndpoint string, customArgs ...str
 	callbackURL, err := url.Parse(aReq.RedirectURI)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to parse redirect uri %s because %v\n", aReq.RedirectURI, err)
+		return nil, err
 	}
 	callbackEndpoint.start(callbackURL.Host, callbackURL.Path)
 

--- a/callback_endpoint.go
+++ b/callback_endpoint.go
@@ -20,40 +20,20 @@ type callbackEndpoint struct {
 	errorMsg         string
 	errorDescription string
 	shutdownSignal   chan string
-	addr             string
-	path             string
-}
-
-func (h *callbackEndpoint) setAddr(addr, defaultAddr string) {
-	if addr == "" {
-		h.addr = defaultAddr
-	} else {
-		h.addr = addr
-	}
-}
-
-func (h *callbackEndpoint) setPath(path, defaultPath string) {
-	if path == "" {
-		h.path = defaultPath
-	} else {
-		h.path = path
-	}
 }
 
 func (h *callbackEndpoint) start(addr, path string) {
 	h.shutdownSignal = make(chan string)
-	h.setAddr(addr, "localhost:9555")
-	h.setPath(path, "/callback")
 
 	server := &http.Server{
-		Addr:           h.addr,
+		Addr:           addr,
 		Handler:        nil,
 		ReadTimeout:    10 * time.Second,
 		WriteTimeout:   10 * time.Second,
 		MaxHeaderBytes: 1 << 20,
 	}
 	h.server = server
-	http.Handle(h.path, h)
+	http.Handle(path, h)
 
 	ln, err := net.Listen("tcp", server.Addr)
 	if err != nil {
@@ -65,7 +45,7 @@ func (h *callbackEndpoint) start(addr, path string) {
 	go func() {
 		server.ListenAndServe()
 	}()
-	fmt.Fprintf(os.Stderr, "started http server for callback endpoint %s%s\n", server.Addr, h.path)
+	fmt.Fprintf(os.Stderr, "started http server for callback endpoint %s%s\n", server.Addr, path)
 }
 
 func (h *callbackEndpoint) stop() {


### PR DESCRIPTION
This parses the callback-uri parameter to determine the address and port for the http server as well as the path that it will listen on for receiving the callback request. Before starting the server, this checks that the requested combination of address and port is free.

Closes #26