### PR TITLE
feat: adds option to skip tls certificate verification

### DIFF
--- a/authorization_request.go
+++ b/authorization_request.go
@@ -70,6 +70,6 @@ func (aReq *AuthorizationRequest) Execute(authEndpoint string, customArgs ...str
 		aResp.Code = callbackEndpoint.code
 		return aResp, nil
 	} else {
-		return nil, fmt.Errorf("authorization failed with error %s and description %s\n", callbackEndpoint.errorMsg, callbackEndpoint.errorDescription)
+		return nil, fmt.Errorf("authorization failed with error %s and description %s", callbackEndpoint.errorMsg, callbackEndpoint.errorDescription)
 	}
 }

--- a/cmd/authorization_code_cfg.go
+++ b/cmd/authorization_code_cfg.go
@@ -19,6 +19,7 @@ func parseAuthorizationCodeFlags(name string, args []string) (runner CommandRunn
 	flags.StringVar(&oidcConf.TokenEndpoint, "token-url", "", "override token url")
 	flags.StringVar(&oidcConf.ClientID, "client-id", "", "set client ID (required)")
 	flags.StringVar(&oidcConf.ClientSecret, "client-secret", "", "set client secret (required if not using PKCE)")
+	flags.BoolVar(&oidcConf.SkipTLSVerify, "skip-tls-verify", false, "skip TLS certificate verification")
 
 	var flowConf oidc.AuthorizationCodeFlowConfig
 	flags.StringVar(&flowConf.Scopes, "scopes", "openid", "set scopes as a space separated list")

--- a/cmd/authorization_code_cfg_test.go
+++ b/cmd/authorization_code_cfg_test.go
@@ -22,6 +22,7 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 				"--discovery-url", "https://example.com/.well-known/openid-configuration",
 				"--authorization-url", "https://example.com/authorize",
 				"--token-url", "https://example.com/token",
+				"--skip-tls-verify",
 				"--client-id", "client-id",
 				"--client-secret", "client-secret",
 				"--scopes", "openid profile email",
@@ -43,6 +44,7 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 				TokenEndpoint:         "https://example.com/token",
 				ClientID:              "client-id",
 				ClientSecret:          "client-secret",
+				SkipTLSVerify: 	   	   true,
 			},
 			oidc.AuthorizationCodeFlowConfig{
 				Scopes:      "openid profile email",

--- a/cmd/oidc-cli.go
+++ b/cmd/oidc-cli.go
@@ -75,7 +75,7 @@ func runCommand(name string, args []string) {
 	}
 
 	if err := command.Run(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v", err.Error())
+		fmt.Fprintf(os.Stderr, "error: %v\n", err.Error())
 		os.Exit(1)
 	}
 }

--- a/introspection_request.go
+++ b/introspection_request.go
@@ -11,7 +11,6 @@ import (
 )
 
 type IntrospectionRequest struct {
-	Endpoint      string
 	Token         string
 	TokenTypeHint string
 	ClientID      string
@@ -19,21 +18,21 @@ type IntrospectionRequest struct {
 	BearerToken   string
 }
 
-func (tReq *IntrospectionRequest) Execute() (tResp *IntrospectionResponse, err error) {
+func (tReq *IntrospectionRequest) Execute(introspectionEndpoint string, httpClient *http.Client) (tResp *IntrospectionResponse, err error) {
 	vals := url.Values{}
 	vals.Set("token", tReq.Token)
 	vals.Set("token_type_hint", tReq.TokenTypeHint)
 
-	fmt.Fprintf(os.Stderr, "introspection endpoint: %s\n", tReq.Endpoint)
+	fmt.Fprintf(os.Stderr, "introspection endpoint: %s\n", introspectionEndpoint)
 	fmt.Fprintf(os.Stderr, "introspection request body: %s\n", vals.Encode())
-	
-	req, err := http.NewRequest("POST", tReq.Endpoint, strings.NewReader(vals.Encode()))
+
+	req, err := http.NewRequest("POST", introspectionEndpoint, strings.NewReader(vals.Encode()))
 	if err != nil {
 		return nil, err
 	}
 	req.SetBasicAuth(tReq.ClientID, tReq.ClientSecret)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/oidc_config.go
+++ b/oidc_config.go
@@ -2,6 +2,7 @@ package oidc
 
 import (
 	"context"
+	"crypto/tls"
 	"log"
 	"net/http"
 )
@@ -16,6 +17,7 @@ type Config struct {
 	IntrospectionEndpoint string
 	UserinfoEndpoint      string
 	JWKSEndpoint          string
+	SkipTLSVerify         bool
 }
 
 func assignIfEmpty(a *string, b string) {
@@ -26,7 +28,14 @@ func assignIfEmpty(a *string, b string) {
 
 func (c *Config) DiscoverEndpoints() {
 	ctx := context.Background()
-	discoveryConfig, err := discover(ctx, c.IssuerUrl, http.DefaultClient, c.DiscoveryEndpoint)
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: c.SkipTLSVerify,
+			},
+		},
+	}
+	discoveryConfig, err := discover(ctx, c.IssuerUrl, client, c.DiscoveryEndpoint)
 
 	if err != nil {
 		log.Fatal(err)

--- a/token_request.go
+++ b/token_request.go
@@ -10,7 +10,6 @@ import (
 )
 
 type TokenRequest struct {
-	Endpoint     string
 	GrantType    string
 	Code         string
 	CodeVerifier string
@@ -20,7 +19,7 @@ type TokenRequest struct {
 	ClientSecret string
 }
 
-func (tReq *TokenRequest) Execute() (tResp *TokenResponse, err error) {
+func (tReq *TokenRequest) Execute(tokenEndpoint string, httpClient *http.Client) (tResp *TokenResponse, err error) {
 	vals := url.Values{}
 	vals.Set("grant_type", tReq.GrantType)
 
@@ -41,10 +40,10 @@ func (tReq *TokenRequest) Execute() (tResp *TokenResponse, err error) {
 		return nil, fmt.Errorf("grant type not implemented yet: %s", tReq.GrantType)
 	}
 
-	fmt.Fprintf(os.Stderr, "token endpoint: %s\n", tReq.Endpoint)
+	fmt.Fprintf(os.Stderr, "token endpoint: %s\n", tokenEndpoint)
 	fmt.Fprintf(os.Stderr, "token request body: %s\n", vals.Encode())
 
-	req, err := http.NewRequest("POST", tReq.Endpoint, strings.NewReader(vals.Encode()))
+	req, err := http.NewRequest("POST", tokenEndpoint, strings.NewReader(vals.Encode()))
 
 	// Set basic auth if username and password are provided
 	if tReq.ClientID != "" && tReq.GrantType == "authorization_code" {
@@ -55,7 +54,7 @@ func (tReq *TokenRequest) Execute() (tResp *TokenResponse, err error) {
 		return nil, err
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This adds the ```--skip-tls-verify``` argument which will skip TLS certificate verification. This is particularly useful when running the cli against a development instance of an authorization server which doesn't have properly signed certificates. The default value of ```false``` will keep TLS verification enabled unless explicitly requested otherwise.