### PR TITLE
removes output that can show secrets

### DIFF
--- a/token_request.go
+++ b/token_request.go
@@ -41,7 +41,6 @@ func (tReq *TokenRequest) Execute(tokenEndpoint string, httpClient *http.Client)
 	}
 
 	fmt.Fprintf(os.Stderr, "token endpoint: %s\n", tokenEndpoint)
-	fmt.Fprintf(os.Stderr, "token request body: %s\n", vals.Encode())
 
 	req, err := http.NewRequest("POST", tokenEndpoint, strings.NewReader(vals.Encode()))
 


### PR DESCRIPTION
Stops printing the body of the request to the token endpoint to avoid showing sensitive information like the client secret. We can add support for debug/verbose output or add obfuscation of the secret later, this is just a quick fix to stop showing by default.