### PR TITLE
feat: implements token refresh flow and simplifies token requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Usage:
 Commands:
   authorization_code: Uses the authorization code flow to get a token response
   client_credentials: Uses the client credentials flow to get a token response
+  introspect        : Uses the introspection flow to validate a token and fetch the associated claims
+  token_refresh     : Uses the token refresh flow to exchange a refresh token and obtain new tokens
   help              : Prints help
 
 Flags:

--- a/cmd/authorization_code_cfg_test.go
+++ b/cmd/authorization_code_cfg_test.go
@@ -44,7 +44,7 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 				TokenEndpoint:         "https://example.com/token",
 				ClientID:              "client-id",
 				ClientSecret:          "client-secret",
-				SkipTLSVerify: 	   	   true,
+				SkipTLSVerify:         true,
 			},
 			oidc.AuthorizationCodeFlowConfig{
 				Scopes:      "openid profile email",

--- a/cmd/oidc-cli.go
+++ b/cmd/oidc-cli.go
@@ -22,6 +22,7 @@ var commands = []Command{
 	{Name: "authorization_code", Help: "Uses the authorization code flow to get a token response", Configure: parseAuthorizationCodeFlags},
 	{Name: "client_credentials", Help: "Uses the client credentials flow to get a token response", Configure: parseClientCredentialsFlags},
 	{Name: "introspect", Help: "Uses the introspection flow to validate a token and fetch the associated claims", Configure: parseIntrospectFlags},
+	{Name: "token_refresh", Help: "Uses the token refresh flow to exchange a refresh token and obtain new tokens", Configure: parseTokenRefreshFlags},
 	{Name: "help", Help: "Prints help"},
 }
 

--- a/cmd/token_refresh_cfg.go
+++ b/cmd/token_refresh_cfg.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"flag"
+	"os"
+
+	oidc "github.com/jentz/vigilant-dollop"
+)
+
+func parseTokenRefreshFlags(name string, args []string) (runner CommandRunner, output string, err error) {
+	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+	var buf bytes.Buffer
+	flags.SetOutput(&buf)
+
+	var oidcConf oidc.Config
+	flags.StringVar(&oidcConf.IssuerUrl, "issuer", "", "set issuer url (required)")
+	flags.StringVar(&oidcConf.DiscoveryEndpoint, "discovery-url", "", "override discovery url")
+	flags.StringVar(&oidcConf.IntrospectionEndpoint, "introspection-url", "", "override introspection url")
+	flags.StringVar(&oidcConf.ClientID, "client-id", "", "set client ID (required)")
+	flags.StringVar(&oidcConf.ClientSecret, "client-secret", "", "set client secret (required unless bearer token is provided)")
+
+	var flowConf oidc.TokenRefreshFlowConfig
+	flags.StringVar(&flowConf.RefreshToken, "refresh-token", "", "refresh token to be used for token refresh")
+
+	runner = &oidc.TokenRefreshFlow{
+		Config:     &oidcConf,
+		FlowConfig: &flowConf,
+	}
+
+	err = flags.Parse(args)
+	if err != nil {
+		return nil, buf.String(), err
+	}
+
+	// Read refresh token from stdin if token equals '-'
+	if flowConf.RefreshToken == "-" {
+		scanner := bufio.NewScanner(os.Stdin)
+		scanner.Scan()
+		flowConf.RefreshToken = scanner.Text()
+	}
+
+	var invalidArgsChecks = []struct {
+		condition bool
+		message   string
+	}{
+		{
+			oidcConf.IssuerUrl == "",
+			"issuer is required",
+		},
+		{
+			oidcConf.ClientID == "",
+			"client-id is required",
+		},
+		{
+			oidcConf.ClientSecret == "",
+			"client-secret or bearer-token is required",
+		},
+		{
+			flowConf.RefreshToken == "",
+			"refresh token is required",
+		},
+	}
+
+	for _, check := range invalidArgsChecks {
+		if check.condition {
+			return nil, check.message, flag.ErrHelp
+		}
+	}
+
+	return runner, buf.String(), nil
+}

--- a/cmd/token_refresh_cfg.go
+++ b/cmd/token_refresh_cfg.go
@@ -18,11 +18,12 @@ func parseTokenRefreshFlags(name string, args []string) (runner CommandRunner, o
 	flags.StringVar(&oidcConf.IssuerUrl, "issuer", "", "set issuer url (required)")
 	flags.StringVar(&oidcConf.DiscoveryEndpoint, "discovery-url", "", "override discovery url")
 	flags.StringVar(&oidcConf.IntrospectionEndpoint, "introspection-url", "", "override introspection url")
-	flags.StringVar(&oidcConf.ClientID, "client-id", "", "set client ID (required)")
-	flags.StringVar(&oidcConf.ClientSecret, "client-secret", "", "set client secret (required unless bearer token is provided)")
+	flags.StringVar(&oidcConf.ClientID, "client-id", "", "set client ID")
+	flags.StringVar(&oidcConf.ClientSecret, "client-secret", "", "set client secret")
 
 	var flowConf oidc.TokenRefreshFlowConfig
 	flags.StringVar(&flowConf.RefreshToken, "refresh-token", "", "refresh token to be used for token refresh")
+	flags.StringVar(&flowConf.Scopes, "scopes", "", "set scopes as a space separated list")
 
 	runner = &oidc.TokenRefreshFlow{
 		Config:     &oidcConf,
@@ -48,14 +49,6 @@ func parseTokenRefreshFlags(name string, args []string) (runner CommandRunner, o
 		{
 			oidcConf.IssuerUrl == "",
 			"issuer is required",
-		},
-		{
-			oidcConf.ClientID == "",
-			"client-id is required",
-		},
-		{
-			oidcConf.ClientSecret == "",
-			"client-secret or bearer-token is required",
 		},
 		{
 			flowConf.RefreshToken == "",

--- a/cmd/token_refresh_cfg_test.go
+++ b/cmd/token_refresh_cfg_test.go
@@ -24,6 +24,7 @@ func TestParseTokenRefreshFlagsResult(t *testing.T) {
 				"--client-id", "client-id",
 				"--client-secret", "client-secret",
 				"--refresh-token", "refresh-token",
+				"--scopes", "openid profile email",
 			},
 			oidc.Config{
 				IssuerUrl:             "https://example.com",
@@ -33,11 +34,12 @@ func TestParseTokenRefreshFlagsResult(t *testing.T) {
 				ClientSecret:          "client-secret",
 			},
 			oidc.TokenRefreshFlowConfig{
+				Scopes:       "openid profile email",
 				RefreshToken: "refresh-token",
 			},
 		},
 		{
-			"only issuer",
+			"only issuer, no scopes",
 			[]string{
 				"--issuer", "https://example.com",
 				"--client-id", "client-id",
@@ -94,14 +96,6 @@ func TestParseTokenRefreshFlagsError(t *testing.T) {
 			},
 		},
 		{
-			"missing client-secret",
-			[]string{
-				"--issuer", "https://example.com",
-				"--discovery-url", "https://example.com/.well-known/openid-configuration",
-				"--client-id", "client-id",
-			},
-		},
-		{
 			"missing refresh token",
 			[]string{
 				"--issuer", "https://example.com",
@@ -110,11 +104,11 @@ func TestParseTokenRefreshFlagsError(t *testing.T) {
 			},
 		},
 		{
-			"bearer token instead of client-secret provided",
+			"undefined argument provided",
 			[]string{
 				"--issuer", "https://example.com",
 				"--client-id", "client-id",
-				"--bearer-token", "bearer",
+				"--undefined-argument", "undefined-argument",
 				"--refresh-token", "refresh-token",
 			},
 		},

--- a/cmd/token_refresh_cfg_test.go
+++ b/cmd/token_refresh_cfg_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	oidc "github.com/jentz/vigilant-dollop"
+)
+
+func TestParseTokenRefreshFlagsResult(t *testing.T) {
+
+	var tests = []struct {
+		name     string
+		args     []string
+		oidcConf oidc.Config
+		flowConf oidc.TokenRefreshFlowConfig
+	}{
+		{
+			"all flags",
+			[]string{
+				"--issuer", "https://example.com",
+				"--discovery-url", "https://example.com/.well-known/openid-configuration",
+				"--introspection-url", "https://example.com/introspection",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+				"--refresh-token", "refresh-token",
+			},
+			oidc.Config{
+				IssuerUrl:             "https://example.com",
+				DiscoveryEndpoint:     "https://example.com/.well-known/openid-configuration",
+				IntrospectionEndpoint: "https://example.com/introspection",
+				ClientID:              "client-id",
+				ClientSecret:          "client-secret",
+			},
+			oidc.TokenRefreshFlowConfig{
+				RefreshToken: "refresh-token",
+			},
+		},
+		{
+			"only issuer",
+			[]string{
+				"--issuer", "https://example.com",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+				"--refresh-token", "refresh-token",
+			},
+			oidc.Config{
+				IssuerUrl:             "https://example.com",
+				DiscoveryEndpoint:     "",
+				IntrospectionEndpoint: "",
+				ClientID:              "client-id",
+				ClientSecret:          "client-secret",
+			},
+			oidc.TokenRefreshFlowConfig{
+				RefreshToken: "refresh-token",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner, output, err := parseTokenRefreshFlags("token_refresh", tt.args)
+			if err != nil {
+				t.Errorf("err got %v, want nil", err)
+			}
+			if output != "" {
+				t.Errorf("output got %q, want empty", output)
+			}
+			f, ok := runner.(*oidc.TokenRefreshFlow)
+			if !ok {
+				t.Errorf("unexpected runner type: %T", runner)
+			}
+			if !reflect.DeepEqual(*f.Config, tt.oidcConf) {
+				t.Errorf("Config got %+v, want %+v", *f.Config, tt.oidcConf)
+			}
+			if !reflect.DeepEqual(*f.FlowConfig, tt.flowConf) {
+				t.Errorf("FlowConfig got %+v, want %+v", *f.FlowConfig, tt.flowConf)
+			}
+		})
+	}
+}
+
+func TestParseTokenRefreshFlagsError(t *testing.T) {
+
+	var tests = []struct {
+		name string
+		args []string
+	}{
+		{
+			"missing issuer",
+			[]string{
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+			},
+		},
+		{
+			"missing client-secret",
+			[]string{
+				"--issuer", "https://example.com",
+				"--discovery-url", "https://example.com/.well-known/openid-configuration",
+				"--client-id", "client-id",
+			},
+		},
+		{
+			"missing refresh token",
+			[]string{
+				"--issuer", "https://example.com",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+			},
+		},
+		{
+			"bearer token instead of client-secret provided",
+			[]string{
+				"--issuer", "https://example.com",
+				"--client-id", "client-id",
+				"--bearer-token", "bearer",
+				"--refresh-token", "refresh-token",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, output, err := parseTokenRefreshFlags("token_refresh", tt.args)
+			if err == nil {
+				t.Errorf("err got nil, want error")
+			}
+			if output == "" {
+				t.Errorf("output got empty, want error message")
+			}
+		})
+	}
+}

--- a/token_refresh.go
+++ b/token_refresh.go
@@ -1,0 +1,47 @@
+package oidc
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+)
+
+type TokenRefreshFlow struct {
+	Config     *Config
+	FlowConfig *TokenRefreshFlowConfig
+}
+
+type TokenRefreshFlowConfig struct {
+	RefreshToken string
+}
+
+func (c *TokenRefreshFlow) Run() error {
+	c.Config.DiscoverEndpoints()
+
+	req := TokenRequest{
+		GrantType:    "refresh_token",
+		ClientID:     c.Config.ClientID,
+		ClientSecret: c.Config.ClientSecret,
+		RefreshToken: c.FlowConfig.RefreshToken,
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: c.Config.SkipTLSVerify,
+			},
+		},
+	}
+
+	resp, err := req.Execute(c.Config.TokenEndpoint, client)
+	if err != nil {
+		return err
+	}
+
+	jsonStr, err := resp.JSON()
+	if err != nil {
+		return err
+	}
+	fmt.Println(jsonStr)
+	return nil
+}

--- a/token_refresh.go
+++ b/token_refresh.go
@@ -12,6 +12,7 @@ type TokenRefreshFlow struct {
 }
 
 type TokenRefreshFlowConfig struct {
+	Scopes       string
 	RefreshToken string
 }
 
@@ -22,6 +23,7 @@ func (c *TokenRefreshFlow) Run() error {
 		GrantType:    "refresh_token",
 		ClientID:     c.Config.ClientID,
 		ClientSecret: c.Config.ClientSecret,
+		Scope:        c.FlowConfig.Scopes,
 		RefreshToken: c.FlowConfig.RefreshToken,
 	}
 


### PR DESCRIPTION
Implements token_refresh command to perform a token refresh. Token refresh expects a refresh token as input, either provided with a command-line parameter or through stdin, while the output is in the same format as other commands.

This also simplifies the implementation of the token request and brings it in line with the authorization request implementation in terms of using gorilla/schema for constructing the request based on the provided attributes.