### PR TITLE
feat: adds support for global flags

### DIFF
--- a/cmd/authorization_code_cfg.go
+++ b/cmd/authorization_code_cfg.go
@@ -7,19 +7,18 @@ import (
 	oidc "github.com/jentz/vigilant-dollop"
 )
 
-func parseAuthorizationCodeFlags(name string, args []string) (runner CommandRunner, output string, err error) {
+func parseAuthorizationCodeFlags(name string, args []string, oidcConf *oidc.Config) (runner CommandRunner, output string, err error) {
 	flags := flag.NewFlagSet(name, flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)
 
-	var oidcConf oidc.Config
-	flags.StringVar(&oidcConf.IssuerUrl, "issuer", "", "set issuer url (required)")
-	flags.StringVar(&oidcConf.DiscoveryEndpoint, "discovery-url", "", "override discovery url")
+	flags.StringVar(&oidcConf.IssuerUrl, "issuer", oidcConf.IssuerUrl, "set issuer url (required)")
+	flags.StringVar(&oidcConf.DiscoveryEndpoint, "discovery-url", oidcConf.DiscoveryEndpoint, "override discovery url")
 	flags.StringVar(&oidcConf.AuthorizationEndpoint, "authorization-url", "", "override authorization url")
 	flags.StringVar(&oidcConf.TokenEndpoint, "token-url", "", "override token url")
-	flags.StringVar(&oidcConf.ClientID, "client-id", "", "set client ID (required)")
-	flags.StringVar(&oidcConf.ClientSecret, "client-secret", "", "set client secret (required if not using PKCE)")
-	flags.BoolVar(&oidcConf.SkipTLSVerify, "skip-tls-verify", false, "skip TLS certificate verification")
+	flags.StringVar(&oidcConf.ClientID, "client-id", oidcConf.ClientID, "set client ID (required)")
+	flags.StringVar(&oidcConf.ClientSecret, "client-secret", oidcConf.ClientSecret, "set client secret (required if not using PKCE)")
+	flags.BoolVar(&oidcConf.SkipTLSVerify, "skip-tls-verify", oidcConf.SkipTLSVerify, "skip TLS certificate verification")
 
 	var flowConf oidc.AuthorizationCodeFlowConfig
 	flags.StringVar(&flowConf.Scopes, "scopes", "openid", "set scopes as a space separated list")
@@ -34,7 +33,7 @@ func parseAuthorizationCodeFlags(name string, args []string) (runner CommandRunn
 	flags.BoolVar(&flowConf.PKCE, "pkce", false, "use proof-key for code exchange (PKCE)")
 
 	runner = &oidc.AuthorizationCodeFlow{
-		Config:     &oidcConf,
+		Config:     oidcConf,
 		FlowConfig: &flowConf,
 	}
 

--- a/cmd/authorization_code_cfg_test.go
+++ b/cmd/authorization_code_cfg_test.go
@@ -199,7 +199,7 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runner, output, err := parseAuthorizationCodeFlags("authorization_code", tt.args)
+			runner, output, err := parseAuthorizationCodeFlags("authorization_code", tt.args, &oidc.Config{})
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
@@ -248,7 +248,7 @@ func TestParseAuthorizationCodeFlagsError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, output, err := parseAuthorizationCodeFlags("authorization_code", tt.args)
+			_, output, err := parseAuthorizationCodeFlags("authorization_code", tt.args, &oidc.Config{})
 			if err == nil {
 				t.Errorf("err got nil, want error")
 			}

--- a/cmd/client_credentials_cfg.go
+++ b/cmd/client_credentials_cfg.go
@@ -7,23 +7,22 @@ import (
 	oidc "github.com/jentz/vigilant-dollop"
 )
 
-func parseClientCredentialsFlags(name string, args []string) (runner CommandRunner, output string, err error) {
+func parseClientCredentialsFlags(name string, args []string, oidcConf *oidc.Config) (runner CommandRunner, output string, err error) {
 	flags := flag.NewFlagSet(name, flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)
 
-	var oidcConf oidc.Config
-	flags.StringVar(&oidcConf.IssuerUrl, "issuer", "", "set issuer url (required)")
-	flags.StringVar(&oidcConf.DiscoveryEndpoint, "discovery-url", "", "override discovery url")
+	flags.StringVar(&oidcConf.IssuerUrl, "issuer", oidcConf.IssuerUrl, "set issuer url (required)")
+	flags.StringVar(&oidcConf.DiscoveryEndpoint, "discovery-url", oidcConf.DiscoveryEndpoint, "override discovery url")
 	flags.StringVar(&oidcConf.TokenEndpoint, "token-url", "", "override token url")
-	flags.StringVar(&oidcConf.ClientID, "client-id", "", "set client ID (required)")
-	flags.StringVar(&oidcConf.ClientSecret, "client-secret", "", "set client secret (required)")
+	flags.StringVar(&oidcConf.ClientID, "client-id", oidcConf.ClientID, "set client ID (required)")
+	flags.StringVar(&oidcConf.ClientSecret, "client-secret", oidcConf.ClientSecret, "set client secret (required)")
 
 	var flowConf oidc.ClientCredentialsFlowConfig
 	flags.StringVar(&flowConf.Scopes, "scopes", "", "set scopes as a space separated list")
 
 	runner = &oidc.ClientCredentialsFlow{
-		Config:     &oidcConf,
+		Config:     oidcConf,
 		FlowConfig: &flowConf,
 	}
 

--- a/cmd/client_credentials_cfg_test.go
+++ b/cmd/client_credentials_cfg_test.go
@@ -78,7 +78,7 @@ func TestParseClientCredentialsFlagsResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runner, output, err := parseClientCredentialsFlags("client_credentials", tt.args)
+			runner, output, err := parseClientCredentialsFlags("client_credentials", tt.args, &oidc.Config{})
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
@@ -124,7 +124,7 @@ func TestParseClientCredentialsFlagsError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, output, err := parseClientCredentialsFlags("client_credentials", tt.args)
+			_, output, err := parseClientCredentialsFlags("client_credentials", tt.args, &oidc.Config{})
 			if err == nil {
 				t.Errorf("err got nil, want error")
 			}

--- a/cmd/global_cfg.go
+++ b/cmd/global_cfg.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+
+	oidc "github.com/jentz/vigilant-dollop"
+)
+
+func parseGlobalFlags(name string, args []string) (oidcConf *oidc.Config, remainingArgs []string, output string, err error) {
+	oidcConf = &oidc.Config{}
+
+	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+	var buf bytes.Buffer
+	flags.SetOutput(&buf)
+
+	flags.StringVar(&oidcConf.IssuerUrl, "issuer", "", "set issuer url (required)")
+	flags.StringVar(&oidcConf.DiscoveryEndpoint, "discovery-url", "", "override discovery url")
+	flags.StringVar(&oidcConf.AuthorizationEndpoint, "authorization-url", "", "override authorization url")
+	flags.StringVar(&oidcConf.TokenEndpoint, "token-url", "", "override token url")
+	flags.StringVar(&oidcConf.ClientID, "client-id", "", "set client ID (required)")
+	flags.StringVar(&oidcConf.ClientSecret, "client-secret", "", "set client secret (required if not using PKCE)")
+	flags.BoolVar(&oidcConf.SkipTLSVerify, "skip-tls-verify", false, "skip TLS certificate verification")
+
+	flags.Parse(args)
+
+	err = flags.Parse(args)
+	if err != nil {
+		return nil, flags.Args(), buf.String(), err
+	}
+
+	return oidcConf, flags.Args(), buf.String(), nil
+}

--- a/cmd/global_cfg.go
+++ b/cmd/global_cfg.go
@@ -14,15 +14,11 @@ func parseGlobalFlags(name string, args []string) (oidcConf *oidc.Config, remain
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)
 
-	flags.StringVar(&oidcConf.IssuerUrl, "issuer", "", "set issuer url (required)")
+	flags.StringVar(&oidcConf.IssuerUrl, "issuer", "", "set issuer url")
 	flags.StringVar(&oidcConf.DiscoveryEndpoint, "discovery-url", "", "override discovery url")
-	flags.StringVar(&oidcConf.AuthorizationEndpoint, "authorization-url", "", "override authorization url")
-	flags.StringVar(&oidcConf.TokenEndpoint, "token-url", "", "override token url")
-	flags.StringVar(&oidcConf.ClientID, "client-id", "", "set client ID (required)")
-	flags.StringVar(&oidcConf.ClientSecret, "client-secret", "", "set client secret (required if not using PKCE)")
+	flags.StringVar(&oidcConf.ClientID, "client-id", "", "set client ID")
+	flags.StringVar(&oidcConf.ClientSecret, "client-secret", "", "set client secret")
 	flags.BoolVar(&oidcConf.SkipTLSVerify, "skip-tls-verify", false, "skip TLS certificate verification")
-
-	flags.Parse(args)
 
 	err = flags.Parse(args)
 	if err != nil {

--- a/cmd/global_cfg_test.go
+++ b/cmd/global_cfg_test.go
@@ -10,9 +10,9 @@ import (
 func TestParseGlobalFlagsResult(t *testing.T) {
 
 	var tests = []struct {
-		name     string
-		args     []string
-		oidcConf oidc.Config
+		name          string
+		args          []string
+		oidcConf      oidc.Config
 		remainingArgs []string
 	}{
 		{
@@ -20,20 +20,16 @@ func TestParseGlobalFlagsResult(t *testing.T) {
 			[]string{
 				"--issuer", "https://example.com",
 				"--discovery-url", "https://example.com/.well-known/openid-configuration",
-				"--authorization-url", "https://example.com/authorize",
-				"--token-url", "https://example.com/token",
 				"--skip-tls-verify",
 				"--client-id", "client-id",
 				"--client-secret", "client-secret",
 			},
 			oidc.Config{
-				IssuerUrl:             "https://example.com",
-				DiscoveryEndpoint:     "https://example.com/.well-known/openid-configuration",
-				AuthorizationEndpoint: "https://example.com/authorize",
-				TokenEndpoint:         "https://example.com/token",
-				ClientID:              "client-id",
-				ClientSecret:          "client-secret",
-				SkipTLSVerify:         true,
+				IssuerUrl:         "https://example.com",
+				DiscoveryEndpoint: "https://example.com/.well-known/openid-configuration",
+				ClientID:          "client-id",
+				ClientSecret:      "client-secret",
+				SkipTLSVerify:     true,
 			},
 			[]string{},
 		},
@@ -45,12 +41,10 @@ func TestParseGlobalFlagsResult(t *testing.T) {
 				"--client-secret", "client-secret",
 			},
 			oidc.Config{
-				IssuerUrl:             "https://example.com",
-				DiscoveryEndpoint:     "",
-				AuthorizationEndpoint: "",
-				TokenEndpoint:         "",
-				ClientID:              "client-id",
-				ClientSecret:          "client-secret",
+				IssuerUrl:         "https://example.com",
+				DiscoveryEndpoint: "",
+				ClientID:          "client-id",
+				ClientSecret:      "client-secret",
 			},
 			[]string{},
 		},
@@ -64,13 +58,11 @@ func TestParseGlobalFlagsResult(t *testing.T) {
 				"--skip-tls-verify",
 			},
 			oidc.Config{
-				IssuerUrl:             "https://example.com",
-				DiscoveryEndpoint:     "",
-				AuthorizationEndpoint: "",
-				TokenEndpoint:         "",
-				ClientID:              "client-id",
-				ClientSecret:          "client-secret",
-				SkipTLSVerify:         false, // expecting default value as argument is not parsed
+				IssuerUrl:         "https://example.com",
+				DiscoveryEndpoint: "",
+				ClientID:          "client-id",
+				ClientSecret:      "client-secret",
+				SkipTLSVerify:     false, // expecting default value as argument is not parsed
 			},
 			[]string{"non-flag-argument", "--skip-tls-verify"},
 		},

--- a/cmd/global_cfg_test.go
+++ b/cmd/global_cfg_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	oidc "github.com/jentz/vigilant-dollop"
+)
+
+func TestParseGlobalFlagsResult(t *testing.T) {
+
+	var tests = []struct {
+		name     string
+		args     []string
+		oidcConf oidc.Config
+		remainingArgs []string
+	}{
+		{
+			"all flags",
+			[]string{
+				"--issuer", "https://example.com",
+				"--discovery-url", "https://example.com/.well-known/openid-configuration",
+				"--authorization-url", "https://example.com/authorize",
+				"--token-url", "https://example.com/token",
+				"--skip-tls-verify",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+			},
+			oidc.Config{
+				IssuerUrl:             "https://example.com",
+				DiscoveryEndpoint:     "https://example.com/.well-known/openid-configuration",
+				AuthorizationEndpoint: "https://example.com/authorize",
+				TokenEndpoint:         "https://example.com/token",
+				ClientID:              "client-id",
+				ClientSecret:          "client-secret",
+				SkipTLSVerify:         true,
+			},
+			[]string{},
+		},
+		{
+			"only issuer",
+			[]string{
+				"--issuer", "https://example.com",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+			},
+			oidc.Config{
+				IssuerUrl:             "https://example.com",
+				DiscoveryEndpoint:     "",
+				AuthorizationEndpoint: "",
+				TokenEndpoint:         "",
+				ClientID:              "client-id",
+				ClientSecret:          "client-secret",
+			},
+			[]string{},
+		},
+		{
+			"flags after non-flag argument",
+			[]string{
+				"--issuer", "https://example.com",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+				"non-flag-argument",
+				"--skip-tls-verify",
+			},
+			oidc.Config{
+				IssuerUrl:             "https://example.com",
+				DiscoveryEndpoint:     "",
+				AuthorizationEndpoint: "",
+				TokenEndpoint:         "",
+				ClientID:              "client-id",
+				ClientSecret:          "client-secret",
+				SkipTLSVerify:         false, // expecting default value as argument is not parsed
+			},
+			[]string{"non-flag-argument", "--skip-tls-verify"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oidcConf, remainingArgs, output, err := parseGlobalFlags("global", tt.args)
+			if err != nil {
+				t.Errorf("err got %v, want nil", err)
+			}
+			if output != "" {
+				t.Errorf("output got %q, want empty", output)
+			}
+			if !reflect.DeepEqual(*oidcConf, tt.oidcConf) {
+				t.Errorf("Config got %+v, want %+v", *oidcConf, tt.oidcConf)
+			}
+			if !reflect.DeepEqual(remainingArgs, tt.remainingArgs) {
+				t.Errorf("remainingArgs got %v, want %v", remainingArgs, tt.remainingArgs)
+			}
+		})
+	}
+}

--- a/cmd/introspect_cfg.go
+++ b/cmd/introspect_cfg.go
@@ -9,17 +9,16 @@ import (
 	oidc "github.com/jentz/vigilant-dollop"
 )
 
-func parseIntrospectFlags(name string, args []string) (runner CommandRunner, output string, err error) {
+func parseIntrospectFlags(name string, args []string, oidcConf *oidc.Config) (runner CommandRunner, output string, err error) {
 	flags := flag.NewFlagSet(name, flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)
 
-	var oidcConf oidc.Config
-	flags.StringVar(&oidcConf.IssuerUrl, "issuer", "", "set issuer url (required)")
-	flags.StringVar(&oidcConf.DiscoveryEndpoint, "discovery-url", "", "override discovery url")
+	flags.StringVar(&oidcConf.IssuerUrl, "issuer", oidcConf.IssuerUrl, "set issuer url (required)")
+	flags.StringVar(&oidcConf.DiscoveryEndpoint, "discovery-url", oidcConf.DiscoveryEndpoint, "override discovery url")
 	flags.StringVar(&oidcConf.IntrospectionEndpoint, "introspection-url", "", "override introspection url")
-	flags.StringVar(&oidcConf.ClientID, "client-id", "", "set client ID (required)")
-	flags.StringVar(&oidcConf.ClientSecret, "client-secret", "", "set client secret (required unless bearer token is provided)")
+	flags.StringVar(&oidcConf.ClientID, "client-id", oidcConf.ClientID, "set client ID (required)")
+	flags.StringVar(&oidcConf.ClientSecret, "client-secret", oidcConf.ClientSecret, "set client secret (required unless bearer token is provided)")
 
 	var flowConf oidc.IntrospectFlowConfig
 	flags.StringVar(&flowConf.BearerToken, "bearer-token", "", "bearer token for authorization (required unless client secret is provided)")
@@ -27,7 +26,7 @@ func parseIntrospectFlags(name string, args []string) (runner CommandRunner, out
 	flags.StringVar(&flowConf.TokenTypeHint, "token-type", "access_token", "token type hint (e.g. access_token")
 
 	runner = &oidc.IntrospectFlow{
-		Config:     &oidcConf,
+		Config:     oidcConf,
 		FlowConfig: &flowConf,
 	}
 

--- a/cmd/introspect_cfg_test.go
+++ b/cmd/introspect_cfg_test.go
@@ -85,7 +85,7 @@ func TestParseIntrospectFlagsResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runner, output, err := parseIntrospectFlags("introspect", tt.args)
+			runner, output, err := parseIntrospectFlags("introspect", tt.args, &oidc.Config{})
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
@@ -139,7 +139,7 @@ func TestParseIntrospectFlagsError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, output, err := parseIntrospectFlags("introspect", tt.args)
+			_, output, err := parseIntrospectFlags("introspect", tt.args, &oidc.Config{})
 			if err == nil {
 				t.Errorf("err got nil, want error")
 			}

--- a/cmd/oidc-cli.go
+++ b/cmd/oidc-cli.go
@@ -83,15 +83,24 @@ func runCommand(name string, args []string) {
 
 func main() {
 	flag.Usage = usage
-	flag.Parse()
+
+	_, args, output, err := parseGlobalFlags("global", os.Args[1:])
+	if errors.Is(err, flag.ErrHelp) {
+		fmt.Println(output)
+		os.Exit(2)
+	} else if err != nil {
+		fmt.Println("got error:", err)
+		fmt.Println("output:\n", output)
+		os.Exit(1)
+	}
 
 	// If no command is specified, print usage and exit
-	if flag.NArg() < 1 {
+	if len(args) < 1 {
 		usage()
 		os.Exit(1)
 	}
 
-	subCmd := flag.Arg(0)
-	subCmdArgs := flag.Args()[1:]
+	subCmd := args[0]
+	subCmdArgs := args[1:]
 	runCommand(subCmd, subCmdArgs)
 }

--- a/cmd/token_refresh_cfg.go
+++ b/cmd/token_refresh_cfg.go
@@ -9,24 +9,23 @@ import (
 	oidc "github.com/jentz/vigilant-dollop"
 )
 
-func parseTokenRefreshFlags(name string, args []string) (runner CommandRunner, output string, err error) {
+func parseTokenRefreshFlags(name string, args []string, oidcConf *oidc.Config) (runner CommandRunner, output string, err error) {
 	flags := flag.NewFlagSet(name, flag.ContinueOnError)
 	var buf bytes.Buffer
 	flags.SetOutput(&buf)
 
-	var oidcConf oidc.Config
-	flags.StringVar(&oidcConf.IssuerUrl, "issuer", "", "set issuer url (required)")
-	flags.StringVar(&oidcConf.DiscoveryEndpoint, "discovery-url", "", "override discovery url")
+	flags.StringVar(&oidcConf.IssuerUrl, "issuer", oidcConf.IssuerUrl, "set issuer url (required)")
+	flags.StringVar(&oidcConf.DiscoveryEndpoint, "discovery-url", oidcConf.DiscoveryEndpoint, "override discovery url")
 	flags.StringVar(&oidcConf.IntrospectionEndpoint, "introspection-url", "", "override introspection url")
-	flags.StringVar(&oidcConf.ClientID, "client-id", "", "set client ID")
-	flags.StringVar(&oidcConf.ClientSecret, "client-secret", "", "set client secret")
+	flags.StringVar(&oidcConf.ClientID, "client-id", oidcConf.ClientID, "set client ID")
+	flags.StringVar(&oidcConf.ClientSecret, "client-secret", oidcConf.ClientSecret, "set client secret")
 
 	var flowConf oidc.TokenRefreshFlowConfig
 	flags.StringVar(&flowConf.RefreshToken, "refresh-token", "", "refresh token to be used for token refresh")
 	flags.StringVar(&flowConf.Scopes, "scopes", "", "set scopes as a space separated list")
 
 	runner = &oidc.TokenRefreshFlow{
-		Config:     &oidcConf,
+		Config:     oidcConf,
 		FlowConfig: &flowConf,
 	}
 

--- a/cmd/token_refresh_cfg_test.go
+++ b/cmd/token_refresh_cfg_test.go
@@ -61,7 +61,7 @@ func TestParseTokenRefreshFlagsResult(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			runner, output, err := parseTokenRefreshFlags("token_refresh", tt.args)
+			runner, output, err := parseTokenRefreshFlags("token_refresh", tt.args, &oidc.Config{})
 			if err != nil {
 				t.Errorf("err got %v, want nil", err)
 			}
@@ -116,7 +116,7 @@ func TestParseTokenRefreshFlagsError(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, output, err := parseTokenRefreshFlags("token_refresh", tt.args)
+			_, output, err := parseTokenRefreshFlags("token_refresh", tt.args, &oidc.Config{})
 			if err == nil {
 				t.Errorf("err got nil, want error")
 			}


### PR DESCRIPTION
This adds the ability for some flags to be provided before the subcommand. This makes it easier to work with aliases, for example when you'd like to have an alias for each instance of an authorization server or for different client configurations.

Known limitations:
* Global flags are not printed in the output of ```oidc-cli help```
* Global flags are not added dynamically to each subcommand.

The limitations could probably be resolved by providing a way to inject the global flagset into the various subcommands' parsing functions as well as into the usage function.