### PR TITLE
feat: adds flag for introspection response format

### DIFF
--- a/cmd/introspect_cfg.go
+++ b/cmd/introspect_cfg.go
@@ -24,6 +24,7 @@ func parseIntrospectFlags(name string, args []string, oidcConf *oidc.Config) (ru
 	flags.StringVar(&flowConf.BearerToken, "bearer-token", "", "bearer token for authorization (required unless client secret is provided)")
 	flags.StringVar(&flowConf.Token, "token", "", "token to be introspected or '-' to read token from stdin (required)")
 	flags.StringVar(&flowConf.TokenTypeHint, "token-type", "access_token", "token type hint (e.g. access_token")
+	flags.StringVar(&flowConf.ResponseFormat, "response-format", "json", "requested format (e.g. json, jwt, token-introspection+jwt)")
 
 	runner = &oidc.IntrospectFlow{
 		Config:     oidcConf,

--- a/cmd/introspect_cfg_test.go
+++ b/cmd/introspect_cfg_test.go
@@ -25,6 +25,7 @@ func TestParseIntrospectFlagsResult(t *testing.T) {
 				"--client-secret", "client-secret",
 				"--token-type", "access_token",
 				"--token", "token",
+				"--response-format", "jwt",
 			},
 			oidc.Config{
 				IssuerUrl:             "https://example.com",
@@ -34,9 +35,10 @@ func TestParseIntrospectFlagsResult(t *testing.T) {
 				ClientSecret:          "client-secret",
 			},
 			oidc.IntrospectFlowConfig{
-				BearerToken:   "",
-				Token:         "token",
-				TokenTypeHint: "access_token",
+				BearerToken:    "",
+				Token:          "token",
+				TokenTypeHint:  "access_token",
+				ResponseFormat: "jwt",
 			},
 		},
 		{
@@ -55,9 +57,10 @@ func TestParseIntrospectFlagsResult(t *testing.T) {
 				ClientSecret:          "client-secret",
 			},
 			oidc.IntrospectFlowConfig{
-				BearerToken:   "",
-				Token:         "token",
-				TokenTypeHint: "access_token",
+				BearerToken:    "",
+				Token:          "token",
+				TokenTypeHint:  "access_token",
+				ResponseFormat: "json",
 			},
 		},
 		{
@@ -76,9 +79,10 @@ func TestParseIntrospectFlagsResult(t *testing.T) {
 				ClientSecret:          "",
 			},
 			oidc.IntrospectFlowConfig{
-				BearerToken:   "bearer",
-				Token:         "token",
-				TokenTypeHint: "access_token",
+				BearerToken:    "bearer",
+				Token:          "token",
+				TokenTypeHint:  "access_token",
+				ResponseFormat: "json",
 			},
 		},
 	}

--- a/introspect.go
+++ b/introspect.go
@@ -12,20 +12,22 @@ type IntrospectFlow struct {
 }
 
 type IntrospectFlowConfig struct {
-	BearerToken   string
-	Token         string
-	TokenTypeHint string
+	BearerToken    string
+	Token          string
+	TokenTypeHint  string
+	ResponseFormat string
 }
 
 func (c *IntrospectFlow) Run() error {
 	c.Config.DiscoverEndpoints()
 
 	req := IntrospectionRequest{
-		ClientID:      c.Config.ClientID,
-		ClientSecret:  c.Config.ClientSecret,
-		Token:         c.FlowConfig.Token,
-		TokenTypeHint: c.FlowConfig.TokenTypeHint,
-		BearerToken:   c.FlowConfig.BearerToken,
+		ClientID:       c.Config.ClientID,
+		ClientSecret:   c.Config.ClientSecret,
+		Token:          c.FlowConfig.Token,
+		TokenTypeHint:  c.FlowConfig.TokenTypeHint,
+		BearerToken:    c.FlowConfig.BearerToken,
+		ResponseFormat: c.FlowConfig.ResponseFormat,
 	}
 
 	client := &http.Client{

--- a/introspection_response.go
+++ b/introspection_response.go
@@ -30,6 +30,7 @@ type IntrospectionResponse struct {
 	AzpClientID    string `json:"azp_client_id,omitempty"`
 	RealmAccess    string `json:"realm_access,omitempty"`
 	ResourceAccess string `json:"resource_access,omitempty"`
+	Jwt            string `json:"jwt,omitempty"`
 }
 
 func (tResp *IntrospectionResponse) JSON() (string, error) {


### PR DESCRIPTION
Adds a `--response-format` flag to the introspect command. This flag can be used to indicated the desired format of the response, in particular to choose between json and a JWT. The default value is `json`. The value required to retrieve a JWT is dependent on the implementation of the authorization server that is used (e.g. for Ping Federate it is `token-introspection+jwt` while for Keycloak it is just `jwt`).