### PR TITLE
feat: adds possibility to indicate desired authentication method

### DIFF
--- a/authorization_code.go
+++ b/authorization_code.go
@@ -98,6 +98,7 @@ func (c *AuthorizationCodeFlow) Run() error {
 		GrantType:    "authorization_code",
 		ClientID:     c.Config.ClientID,
 		ClientSecret: c.Config.ClientSecret,
+		AuthMethod:   c.Config.AuthMethod,
 		RedirectURI:  c.FlowConfig.CallbackURI,
 		CodeVerifier: codeVerifier,
 		Code:         aResp.Code,

--- a/authorization_code.go
+++ b/authorization_code.go
@@ -52,6 +52,7 @@ func (c *AuthorizationCodeFlow) Run() error {
 			MaxAge:       c.FlowConfig.MaxAge,
 			UILocales:    c.FlowConfig.UILocales,
 			State:        c.FlowConfig.State,
+			AuthMethod:   c.Config.AuthMethod,
 		}
 		if c.FlowConfig.PKCE {
 			// Starting with a byte array of 31-96 bytes ensures that the base64 encoded string will be between 43 and 128 characters long as required by RFC7636

--- a/client_credentials.go
+++ b/client_credentials.go
@@ -22,6 +22,7 @@ func (c *ClientCredentialsFlow) Run() error {
 		GrantType:    "client_credentials",
 		ClientID:     c.Config.ClientID,
 		ClientSecret: c.Config.ClientSecret,
+		AuthMethod:   c.Config.AuthMethod,
 	}
 
 	if c.FlowConfig.Scopes != "" {

--- a/cmd/authorization_code_cfg.go
+++ b/cmd/authorization_code_cfg.go
@@ -19,6 +19,7 @@ func parseAuthorizationCodeFlags(name string, args []string, oidcConf *oidc.Conf
 	flags.StringVar(&oidcConf.ClientID, "client-id", oidcConf.ClientID, "set client ID (required)")
 	flags.StringVar(&oidcConf.ClientSecret, "client-secret", oidcConf.ClientSecret, "set client secret (required if not using PKCE)")
 	flags.BoolVar(&oidcConf.SkipTLSVerify, "skip-tls-verify", oidcConf.SkipTLSVerify, "skip TLS certificate verification")
+	flags.Var(&oidcConf.AuthMethod, "auth-method", "auth method to use (client_secret_basic or client_secret_post)")
 
 	var flowConf oidc.AuthorizationCodeFlowConfig
 	flags.StringVar(&flowConf.Scopes, "scopes", "openid", "set scopes as a space separated list")
@@ -40,7 +41,7 @@ func parseAuthorizationCodeFlags(name string, args []string, oidcConf *oidc.Conf
 
 	err = flags.Parse(args)
 	if err != nil {
-		return nil, buf.String(), err
+		return nil, buf.String(), flag.ErrHelp
 	}
 
 	var invalidArgsChecks = []struct {

--- a/cmd/client_credentials_cfg.go
+++ b/cmd/client_credentials_cfg.go
@@ -17,6 +17,7 @@ func parseClientCredentialsFlags(name string, args []string, oidcConf *oidc.Conf
 	flags.StringVar(&oidcConf.TokenEndpoint, "token-url", "", "override token url")
 	flags.StringVar(&oidcConf.ClientID, "client-id", oidcConf.ClientID, "set client ID (required)")
 	flags.StringVar(&oidcConf.ClientSecret, "client-secret", oidcConf.ClientSecret, "set client secret (required)")
+	flags.Var(&oidcConf.AuthMethod, "auth-method", "auth method to use (client_secret_basic or client_secret_post)")
 
 	var flowConf oidc.ClientCredentialsFlowConfig
 	flags.StringVar(&flowConf.Scopes, "scopes", "", "set scopes as a space separated list")

--- a/cmd/introspect_cfg.go
+++ b/cmd/introspect_cfg.go
@@ -19,6 +19,7 @@ func parseIntrospectFlags(name string, args []string, oidcConf *oidc.Config) (ru
 	flags.StringVar(&oidcConf.IntrospectionEndpoint, "introspection-url", "", "override introspection url")
 	flags.StringVar(&oidcConf.ClientID, "client-id", oidcConf.ClientID, "set client ID (required)")
 	flags.StringVar(&oidcConf.ClientSecret, "client-secret", oidcConf.ClientSecret, "set client secret (required unless bearer token is provided)")
+	flags.Var(&oidcConf.AuthMethod, "auth-method", "auth method to use (client_secret_basic or client_secret_post)")
 
 	var flowConf oidc.IntrospectFlowConfig
 	flags.StringVar(&flowConf.BearerToken, "bearer-token", "", "bearer token for authorization (required unless client secret is provided)")

--- a/cmd/oidc-cli.go
+++ b/cmd/oidc-cli.go
@@ -69,7 +69,7 @@ func runCommand(name string, args []string, globalConf *oidc.Config) {
 
 	command, output, err := cmd.Configure(name, args, globalConf)
 	if errors.Is(err, flag.ErrHelp) {
-		fmt.Println(output)
+		fmt.Fprintf(os.Stderr, "error: %v\n", output)
 		os.Exit(2)
 	} else if err != nil {
 		fmt.Println("got error:", err)

--- a/cmd/token_refresh_cfg.go
+++ b/cmd/token_refresh_cfg.go
@@ -19,6 +19,7 @@ func parseTokenRefreshFlags(name string, args []string, oidcConf *oidc.Config) (
 	flags.StringVar(&oidcConf.IntrospectionEndpoint, "introspection-url", "", "override introspection url")
 	flags.StringVar(&oidcConf.ClientID, "client-id", oidcConf.ClientID, "set client ID")
 	flags.StringVar(&oidcConf.ClientSecret, "client-secret", oidcConf.ClientSecret, "set client secret")
+	flags.Var(&oidcConf.AuthMethod, "auth-method", "auth method to use (client_secret_basic or client_secret_post)")
 
 	var flowConf oidc.TokenRefreshFlowConfig
 	flags.StringVar(&flowConf.RefreshToken, "refresh-token", "", "refresh token to be used for token refresh")

--- a/discovery.go
+++ b/discovery.go
@@ -12,15 +12,16 @@ const (
 )
 
 type DiscoveryConfiguration struct {
-	Issuer                             string `json:"issuer,omitempty"`
-	AuthorizationEndpoint              string `json:"authorization_endpoint,omitempty"`
+	Issuer                             string   `json:"issuer,omitempty"`
+	AuthorizationEndpoint              string   `json:"authorization_endpoint,omitempty"`
 	PushedAuthorizationRequestEndpoint string `json:"pushed_authorization_request_endpoint,omitempty"`
-	TokenEndpoint                      string `json:"token_endpoint,omitempty"`
-	IntrospectionEndpoint              string `json:"introspection_endpoint,omitempty"`
-	UserinfoEndpoint                   string `json:"userinfo_endpoint,omitempty"`
-	RevocationEndpoint                 string `json:"revocation_endpoint,omitempty"`
-	DeviceAuthorizationEndpoint        string `json:"device_authorization_endpoint,omitempty"`
-	JwksURI                            string `json:"jwks_uri,omitempty"`
+	TokenEndpoint                      string   `json:"token_endpoint,omitempty"`
+	IntrospectionEndpoint              string   `json:"introspection_endpoint,omitempty"`
+	UserinfoEndpoint                   string   `json:"userinfo_endpoint,omitempty"`
+	RevocationEndpoint                 string   `json:"revocation_endpoint,omitempty"`
+	DeviceAuthorizationEndpoint        string   `json:"device_authorization_endpoint,omitempty"`
+	JwksURI                            string   `json:"jwks_uri,omitempty"`
+	TokenEndpointAuthMethods   		   []string `json:"token_endpoint_auth_methods_supported,omitempty"`
 }
 
 func discover(ctx context.Context, issuer string, httpClient *http.Client, wellKnownUrl ...string) (*DiscoveryConfiguration, error) {

--- a/discovery.go
+++ b/discovery.go
@@ -14,14 +14,14 @@ const (
 type DiscoveryConfiguration struct {
 	Issuer                             string   `json:"issuer,omitempty"`
 	AuthorizationEndpoint              string   `json:"authorization_endpoint,omitempty"`
-	PushedAuthorizationRequestEndpoint string `json:"pushed_authorization_request_endpoint,omitempty"`
+	PushedAuthorizationRequestEndpoint string   `json:"pushed_authorization_request_endpoint,omitempty"`
 	TokenEndpoint                      string   `json:"token_endpoint,omitempty"`
 	IntrospectionEndpoint              string   `json:"introspection_endpoint,omitempty"`
 	UserinfoEndpoint                   string   `json:"userinfo_endpoint,omitempty"`
 	RevocationEndpoint                 string   `json:"revocation_endpoint,omitempty"`
 	DeviceAuthorizationEndpoint        string   `json:"device_authorization_endpoint,omitempty"`
 	JwksURI                            string   `json:"jwks_uri,omitempty"`
-	TokenEndpointAuthMethods   		   []string `json:"token_endpoint_auth_methods_supported,omitempty"`
+	TokenEndpointAuthMethods           []string `json:"token_endpoint_auth_methods_supported,omitempty"`
 }
 
 func discover(ctx context.Context, issuer string, httpClient *http.Client, wellKnownUrl ...string) (*DiscoveryConfiguration, error) {

--- a/introspect.go
+++ b/introspect.go
@@ -28,6 +28,7 @@ func (c *IntrospectFlow) Run() error {
 		TokenTypeHint:  c.FlowConfig.TokenTypeHint,
 		BearerToken:    c.FlowConfig.BearerToken,
 		ResponseFormat: c.FlowConfig.ResponseFormat,
+		AuthMethod:    c.Config.AuthMethod,
 	}
 
 	client := &http.Client{

--- a/introspect.go
+++ b/introspect.go
@@ -28,7 +28,7 @@ func (c *IntrospectFlow) Run() error {
 		TokenTypeHint:  c.FlowConfig.TokenTypeHint,
 		BearerToken:    c.FlowConfig.BearerToken,
 		ResponseFormat: c.FlowConfig.ResponseFormat,
-		AuthMethod:    c.Config.AuthMethod,
+		AuthMethod:     c.Config.AuthMethod,
 	}
 
 	client := &http.Client{

--- a/oidc_config.go
+++ b/oidc_config.go
@@ -45,7 +45,7 @@ type Config struct {
 	JWKSEndpoint                       string
 	SkipTLSVerify                      bool
 	Verbose                            bool
-	AuthMethod            AuthMethodValue
+	AuthMethod                         AuthMethodValue
 }
 
 func assignIfEmpty[T any](a *T, b T) {

--- a/oidc_config.go
+++ b/oidc_config.go
@@ -3,9 +3,34 @@ package oidc
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"log"
 	"net/http"
+	"reflect"
 )
+
+type AuthMethodValue string
+
+const (
+	AuthMethodClientSecretBasic AuthMethodValue = "client_secret_basic"
+	AuthMethodClientSecretPost  AuthMethodValue = "client_secret_post"
+)
+
+func (a *AuthMethodValue) Set(value string) error {
+	if !AuthMethodValue(value).IsValid() {
+		return fmt.Errorf("invalid auth method, valid values are %s", []AuthMethodValue{AuthMethodClientSecretBasic, AuthMethodClientSecretPost})
+	}
+	*a = AuthMethodValue(value)
+	return nil
+}
+
+func (a *AuthMethodValue) String() string {
+	return string(*a)
+}
+
+func (a AuthMethodValue) IsValid() bool {
+	return a == AuthMethodClientSecretBasic || a == AuthMethodClientSecretPost
+}
 
 type Config struct {
 	ClientID                           string
@@ -20,10 +45,11 @@ type Config struct {
 	JWKSEndpoint                       string
 	SkipTLSVerify                      bool
 	Verbose                            bool
+	AuthMethod            AuthMethodValue
 }
 
-func assignIfEmpty(a *string, b string) {
-	if *a == "" {
+func assignIfEmpty[T any](a *T, b T) {
+	if reflect.ValueOf(*a).IsZero() {
 		*a = b
 	}
 }
@@ -49,6 +75,14 @@ func (c *Config) DiscoverEndpoints() {
 	assignIfEmpty(&c.IntrospectionEndpoint, discoveryConfig.IntrospectionEndpoint)
 	assignIfEmpty(&c.UserinfoEndpoint, discoveryConfig.UserinfoEndpoint)
 	assignIfEmpty(&c.JWKSEndpoint, discoveryConfig.JwksURI)
+
+	// use first supported auth method unless set through flag
+	for _, method := range discoveryConfig.TokenEndpointAuthMethods {
+		if AuthMethodValue(method).IsValid() {
+			assignIfEmpty(&c.AuthMethod, AuthMethodValue(method))
+			break
+		}
+	}
 }
 
 type CustomArgs []string

--- a/token_refresh.go
+++ b/token_refresh.go
@@ -25,6 +25,7 @@ func (c *TokenRefreshFlow) Run() error {
 		ClientSecret: c.Config.ClientSecret,
 		Scope:        c.FlowConfig.Scopes,
 		RefreshToken: c.FlowConfig.RefreshToken,
+		AuthMethod:   c.Config.AuthMethod,
 	}
 
 	client := &http.Client{

--- a/token_request.go
+++ b/token_request.go
@@ -31,6 +31,11 @@ func (tReq *TokenRequest) Execute(tokenEndpoint string, verbose bool, httpClient
 		return nil, err
 	}
 
+	if tReq.AuthMethod == AuthMethodClientSecretBasic {
+		body.Del("client_id")
+		body.Del("client_secret")
+	}
+
 	if verbose {
 		fmt.Fprintf(os.Stderr, "token endpoint: %s\n", tokenEndpoint)
 		maskedBody := url.Values{}
@@ -44,11 +49,6 @@ func (tReq *TokenRequest) Execute(tokenEndpoint string, verbose bool, httpClient
 		if len(maskedBody) > 0 {
 			fmt.Fprintf(os.Stderr, "token request body: %s\n", maskedBody.Encode())
 		}
-	}
-
-	if tReq.AuthMethod == AuthMethodClientSecretBasic {
-		body.Del("client_id")
-		body.Del("client_secret")
 	}
 
 	req, err := http.NewRequest("POST", tokenEndpoint, strings.NewReader(body.Encode()))


### PR DESCRIPTION
Adds identification of supported authentication methods during discovery. Also adds the option of indicating the desired authentication method using the `--auth-method` command-line argument. 

Known limitations:
* Currently, only support for `client_secret_basic` and `client_secret_post` has been implemented.