### PR TITLE
feature: implements support for dpop (RFC9449)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ dist/
 
 # asdf
 .tool-versions
+
+# local tmp
+tmp/

--- a/authorization_code.go
+++ b/authorization_code.go
@@ -30,6 +30,7 @@ type AuthorizationCodeFlowConfig struct {
 
 func (c *AuthorizationCodeFlow) Run() error {
 	c.Config.DiscoverEndpoints()
+	c.Config.ReadKeyFiles()
 
 	aReq := AuthorizationRequest{}
 	var codeVerifier string

--- a/authorization_code.go
+++ b/authorization_code.go
@@ -110,11 +110,16 @@ func (c *AuthorizationCodeFlow) Run() error {
 	}
 
 	if c.FlowConfig.DPoP {
-		dpopHeader, err := crypto.CreateDpopProof(c.Config.PrivateKey, c.Config.PublicKey, "POST", c.Config.TokenEndpoint)
+		builder := crypto.NewDPoPProofBuilder()
+		builder.PublicKey(c.Config.PublicKey)
+		builder.PrivateKey(c.Config.PrivateKey)
+		builder.Method("POST")
+		builder.Url(c.Config.TokenEndpoint)
+		dpopProof, err := builder.Build()
 		if err != nil {
 			return err
 		}
-		tReq.DPoPHeader = dpopHeader
+		tReq.DPoPHeader = dpopProof.String()
 	}
 
 	tResp, err := tReq.Execute(c.Config.TokenEndpoint, c.Config.Verbose, client)

--- a/authorization_code.go
+++ b/authorization_code.go
@@ -60,8 +60,8 @@ func (c *AuthorizationCodeFlow) Run() error {
 		}
 		if c.FlowConfig.PKCE {
 			// Starting with a byte array of 31-96 bytes ensures that the base64 encoded string will be between 43 and 128 characters long as required by RFC7636
-			codeVerifier = crypto.CreatePkceCodeVerifier(crypto.RandomInt(32, 96))
-			parReq.CodeChallenge = crypto.CreatePkceCodeChallenge(codeVerifier)
+			codeVerifier = crypto.GeneratePKCECodeVerifier(crypto.RandomInt(32, 96))
+			parReq.CodeChallenge = crypto.GeneratePKCECodeChallenge(codeVerifier)
 			parReq.CodeChallengeMethod = "S256"
 		}
 		parResp, err := parReq.Execute(c.Config.PushedAuthorizationRequestEndpoint, c.Config.Verbose, client, c.FlowConfig.CustomArgs...)
@@ -88,8 +88,8 @@ func (c *AuthorizationCodeFlow) Run() error {
 		}
 		if c.FlowConfig.PKCE {
 			// Starting with a byte array of 31-96 bytes ensures that the base64 encoded string will be between 43 and 128 characters long as required by RFC7636
-			codeVerifier = crypto.CreatePkceCodeVerifier(crypto.RandomInt(32, 96))
-			aReq.CodeChallenge = crypto.CreatePkceCodeChallenge(codeVerifier)
+			codeVerifier = crypto.GeneratePKCECodeVerifier(crypto.RandomInt(32, 96))
+			aReq.CodeChallenge = crypto.GeneratePKCECodeChallenge(codeVerifier)
 			aReq.CodeChallengeMethod = "S256"
 		}
 	}
@@ -110,12 +110,11 @@ func (c *AuthorizationCodeFlow) Run() error {
 	}
 
 	if c.FlowConfig.DPoP {
-		builder := crypto.NewDPoPProofBuilder()
-		builder.PublicKey(c.Config.PublicKey)
-		builder.PrivateKey(c.Config.PrivateKey)
-		builder.Method("POST")
-		builder.Url(c.Config.TokenEndpoint)
-		dpopProof, err := builder.Build()
+		dpopProof, err := crypto.NewDPoPProof(
+			c.Config.PublicKey,
+			c.Config.PrivateKey,
+			"POST",
+			c.Config.TokenEndpoint)
 		if err != nil {
 			return err
 		}

--- a/cmd/authorization_code_cfg.go
+++ b/cmd/authorization_code_cfg.go
@@ -3,10 +3,8 @@ package main
 import (
 	"bytes"
 	"flag"
-	"fmt"
 
 	oidc "github.com/jentz/vigilant-dollop"
-	"github.com/jentz/vigilant-dollop/pkg/crypto"
 )
 
 func parseAuthorizationCodeFlags(name string, args []string, oidcConf *oidc.Config) (runner CommandRunner, output string, err error) {
@@ -82,30 +80,6 @@ func parseAuthorizationCodeFlags(name string, args []string, oidcConf *oidc.Conf
 	for _, check := range invalidArgsChecks {
 		if check.condition {
 			return nil, check.message, flag.ErrHelp
-		}
-	}
-
-	// Parse the private key if provided
-	if oidcConf.PrivateKeyFile != "" {
-		pem, err := crypto.ReadPEMBlockFromFile(oidcConf.PrivateKeyFile)
-		if err != nil {
-			return nil, fmt.Sprintf("failed to read private key file: %v", err), flag.ErrHelp
-		}
-		oidcConf.PrivateKey, err = crypto.ParsePrivateKeyPEMBlock(pem)
-		if err != nil {
-			return nil, fmt.Sprintf("failed to parse private key: %v", err), flag.ErrHelp
-		}
-	}
-
-	// Parse the public key if provided
-	if oidcConf.PublicKeyFile != "" {
-		pem, err := crypto.ReadPEMBlockFromFile(oidcConf.PublicKeyFile)
-		if err != nil {
-			return nil, fmt.Sprintf("failed to read public key file: %v", err), flag.ErrHelp
-		}
-		oidcConf.PublicKey, err = crypto.ParsePublicKeyPEMBlock(pem)
-		if err != nil {
-			return nil, fmt.Sprintf("failed to parse public key: %v", err), flag.ErrHelp
 		}
 	}
 

--- a/cmd/authorization_code_cfg_test.go
+++ b/cmd/authorization_code_cfg_test.go
@@ -36,6 +36,10 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 				"--custom", "custom1=value1",
 				"--custom", "custom2=value2",
 				"--pkce",
+				"--par",
+				"--dpop",
+				"--private-key", "path/to/private-key.pem",
+				"--public-key", "path/to/public-key.pem",
 			},
 			oidc.Config{
 				IssuerUrl:             "https://example.com",
@@ -45,6 +49,8 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 				ClientID:              "client-id",
 				ClientSecret:          "client-secret",
 				SkipTLSVerify:         true,
+				PrivateKeyFile:        "path/to/private-key.pem",
+				PublicKeyFile:         "path/to/public-key.pem",
 			},
 			oidc.AuthorizationCodeFlowConfig{
 				Scopes:      "openid profile email",
@@ -57,6 +63,8 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 				State:       "state",
 				CustomArgs:  oidc.CustomArgs{"custom1=value1", "custom2=value2"},
 				PKCE:        true,
+				PAR:         true,
+				DPoP:        true,
 			},
 		},
 		{
@@ -80,6 +88,8 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 				Scopes:      "openid profile email",
 				CallbackURI: "http://localhost:8080/callback",
 				PKCE:        false,
+				PAR:         false,
+				DPoP:        false,
 			},
 		},
 		{
@@ -102,6 +112,8 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 				Scopes:      "openid",
 				CallbackURI: "http://localhost:8080/callback",
 				PKCE:        false,
+				PAR:         false,
+				DPoP:        false,
 			},
 		},
 		{
@@ -124,6 +136,8 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 				Scopes:      "openid profile email",
 				CallbackURI: "http://localhost:9555/callback",
 				PKCE:        false,
+				PAR:         false,
+				DPoP:        false,
 			},
 		},
 		{
@@ -147,6 +161,8 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 				Scopes:      "openid profile email",
 				CallbackURI: "http://localhost:9555/callback",
 				PKCE:        true,
+				PAR:         false,
+				DPoP:        false,
 			},
 		},
 		{
@@ -169,6 +185,37 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 				Scopes:      "openid profile email",
 				CallbackURI: "http://localhost:9555/callback",
 				PKCE:        true,
+				PAR:         false,
+				DPoP:        false,
+			},
+		},
+		{
+			"dpop with private and public certificate",
+			[]string{
+				"--issuer", "https://example.com",
+				"--client-id", "client-id",
+				"--client-secret", "client-secret",
+				"--scopes", "openid profile email",
+				"--dpop",
+				"--private-key", "path/to/private-key.pem",
+				"--public-key", "path/to/public-key.pem",
+			},
+			oidc.Config{
+				IssuerUrl:             "https://example.com",
+				DiscoveryEndpoint:     "",
+				AuthorizationEndpoint: "",
+				TokenEndpoint:         "",
+				ClientID:              "client-id",
+				ClientSecret:          "client-secret",
+				PrivateKeyFile:        "path/to/private-key.pem",
+				PublicKeyFile:         "path/to/public-key.pem",
+			},
+			oidc.AuthorizationCodeFlowConfig{
+				Scopes:      "openid profile email",
+				CallbackURI: "http://localhost:9555/callback",
+				PKCE:        false,
+				PAR:         false,
+				DPoP:        true,
 			},
 		},
 		{
@@ -193,6 +240,8 @@ func TestParseAuthorizationCodeFlagsResult(t *testing.T) {
 				Scopes:      "openid",                         // expecting default value as argument is not parsed
 				CallbackURI: "http://localhost:9555/callback", // expecting default value as argument is not parsed
 				PKCE:        false,
+				PAR:         false,
+				DPoP:        false,
 			},
 		},
 	}
@@ -242,6 +291,28 @@ func TestParseAuthorizationCodeFlagsError(t *testing.T) {
 				"--client-id", "client-id",
 				"--scopes", "openid profile email",
 				"--callback-uri", "http://localhost:8080/callback",
+			},
+		},
+		{
+			"missing private-key and dpop",
+			[]string{
+				"--issuer", "https://example.com",
+				"--client-id", "client-id",
+				"--scopes", "openid profile email",
+				"--callback-uri", "http://localhost:8080/callback",
+				"--dpop",
+				"--public-key", "path/to/public-key.pem",
+			},
+		},
+		{
+			"missing public-key and dpop",
+			[]string{
+				"--issuer", "https://example.com",
+				"--client-id", "client-id",
+				"--scopes", "openid profile email",
+				"--callback-uri", "http://localhost:8080/callback",
+				"--dpop",
+				"--private-key", "path/to/private-key.pem",
 			},
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/jentz/vigilant-dollop
 go 1.21
 
 require github.com/gorilla/schema v1.4.1
+
+require github.com/golang-jwt/jwt/v5 v5.2.2

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/golang-jwt/jwt/v5 v5.2.2 h1:Rl4B7itRWVtYIHFrSNd7vhTiz9UpLdi6gZhZ3wEeDy8=
+github.com/golang-jwt/jwt/v5 v5.2.2/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/gorilla/schema v1.4.1 h1:jUg5hUjCSDZpNGLuXQOgIWGdlgrIdYvgQ0wZtdK1M3E=
 github.com/gorilla/schema v1.4.1/go.mod h1:Dg5SSm5PV60mhF2NFaTV1xuYYj8tV8NOPRo4FggUMnM=

--- a/oidc_config.go
+++ b/oidc_config.go
@@ -46,6 +46,10 @@ type Config struct {
 	SkipTLSVerify                      bool
 	Verbose                            bool
 	AuthMethod                         AuthMethodValue
+	PrivateKeyFile                     string
+	PublicKeyFile                      string
+	PrivateKey                         any
+	PublicKey                          any
 }
 
 func assignIfEmpty[T any](a *T, b T) {

--- a/oidc_config.go
+++ b/oidc_config.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"net/http"
 	"reflect"
+
+	"github.com/jentz/vigilant-dollop/pkg/crypto"
 )
 
 type AuthMethodValue string
@@ -85,6 +87,32 @@ func (c *Config) DiscoverEndpoints() {
 		if AuthMethodValue(method).IsValid() {
 			assignIfEmpty(&c.AuthMethod, AuthMethodValue(method))
 			break
+		}
+	}
+}
+
+func (c *Config) ReadKeyFiles() {
+	// Parse the private key if provided
+	if c.PrivateKeyFile != "" {
+		pem, err := crypto.ReadPEMBlockFromFile(c.PrivateKeyFile)
+		if err != nil {
+			log.Fatal(fmt.Errorf("failed to read private key file: %v", err))
+		}
+		c.PrivateKey, err = crypto.ParsePrivateKeyPEMBlock(pem)
+		if err != nil {
+			log.Fatal(fmt.Errorf("failed to parse private key: %v", err))
+		}
+	}
+
+	// Parse the public key if provided
+	if c.PublicKeyFile != "" {
+		pem, err := crypto.ReadPEMBlockFromFile(c.PublicKeyFile)
+		if err != nil {
+			log.Fatal(fmt.Errorf("failed to read public key file: %v", err))
+		}
+		c.PublicKey, err = crypto.ParsePublicKeyPEMBlock(pem)
+		if err != nil {
+			log.Fatal(fmt.Errorf("failed to parse public key: %v", err))
 		}
 	}
 }

--- a/pkg/crypto/dpop.go
+++ b/pkg/crypto/dpop.go
@@ -1,0 +1,168 @@
+package crypto
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type ecdsaJWK struct {
+	X   string `json:"x"`
+	Y   string `json:"y"`
+	Crv string `json:"crv"`
+	Kty string `json:"kty"`
+}
+
+type rsaJWK struct {
+	Exponent string `json:"e"`
+	Modulus  string `json:"n"`
+	Kty      string `json:"kty"`
+}
+
+type ed25519JWK struct {
+	PublicKey string `json:"x"`
+	Kty       string `json:"kty"`
+}
+
+func CreateDpopProof(privateKey any, publicKey any, method string, url string) (string, error) {
+
+	var jwk any
+	var alg string
+	var jwtSigningMethod jwt.SigningMethod
+
+	switch k := publicKey.(type) {
+
+	case *ecdsa.PublicKey:
+		if _, ok := privateKey.(*ecdsa.PrivateKey); !ok {
+			return "", fmt.Errorf("private key type does not match public key type")
+		}
+		jwk = convertPublicKeyToEcdsaJwk(publicKey.(*ecdsa.PublicKey))
+		alg = ecdsaAlgorithmString(publicKey.(*ecdsa.PublicKey))
+		jwtSigningMethod = jwt.SigningMethodES256
+
+	case *rsa.PublicKey:
+		if _, ok := privateKey.(*rsa.PrivateKey); !ok {
+			return "", fmt.Errorf("private key type does not match public key type")
+		}
+		jwk = convertPublicKeyToRsaJwk(publicKey.(*rsa.PublicKey))
+		alg = rsaAlgorithmString(publicKey.(*rsa.PublicKey))
+		jwtSigningMethod = jwt.SigningMethodRS256
+
+	case ed25519.PublicKey:
+		if _, ok := privateKey.(ed25519.PrivateKey); !ok {
+			return "", fmt.Errorf("private key type does not match public key type")
+		}
+		jwk = convertPublicKeyToEd25519Jwk(publicKey.(ed25519.PublicKey))
+		alg = ed25519AlgorithmString()
+		jwtSigningMethod = jwt.SigningMethodEdDSA
+
+	default:
+		return "", fmt.Errorf("unsupported public key type: %T", k)
+	}
+
+	token := constructDpopToken(jwk, alg, generateJTI(), method, url, jwtSigningMethod)
+
+	signedToken, err := token.SignedString(privateKey)
+	if err != nil {
+		return "", fmt.Errorf("error signing DPoP JWT: %w", err)
+	}
+
+	return signedToken, nil
+}
+
+func constructDpopToken(jwk any, alg string, jti string, method string, url string, jwtSigningMethod jwt.SigningMethod) *jwt.Token {
+	header := map[string]any{
+		"typ": "dpop+jwt",
+		"alg": alg,
+		"jwk": jwk,
+	}
+
+	claims := jwt.MapClaims{
+		"jti": jti,
+		"htm": method,
+		"htu": url,
+		"iat": time.Now().Unix(),
+	}
+
+	token := jwt.NewWithClaims(jwtSigningMethod, claims)
+	token.Header = header
+
+	return token
+}
+
+func generateJTI() string {
+	randomBytes := make([]byte, 30)
+	_, err := rand.Read(randomBytes)
+	if err != nil {
+		panic(err)
+	}
+	hash := sha256.Sum256(randomBytes)
+	return base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+func convertPublicKeyToEcdsaJwk(k *ecdsa.PublicKey) any {
+	// Calculate the size of the byte array representation of an elliptic curve coordinate
+	// and ensure that the byte array representation of the key is padded correctly.
+	bits := k.Curve.Params().BitSize
+	keyCurveBytesSize := bits/8 + bits%8
+
+	return &ecdsaJWK{
+		X:   base64.RawURLEncoding.EncodeToString(k.X.FillBytes(make([]byte, keyCurveBytesSize))),
+		Y:   base64.RawURLEncoding.EncodeToString(k.Y.FillBytes(make([]byte, keyCurveBytesSize))),
+		Crv: k.Curve.Params().Name,
+		Kty: "EC",
+	}
+}
+
+func convertPublicKeyToRsaJwk(k *rsa.PublicKey) any {
+	return &rsaJWK{
+		Exponent: base64.RawURLEncoding.EncodeToString(big.NewInt(int64(k.E)).Bytes()),
+		Modulus:  base64.RawURLEncoding.EncodeToString(k.N.Bytes()),
+		Kty:      "RSA",
+	}
+}
+
+func convertPublicKeyToEd25519Jwk(k ed25519.PublicKey) any {
+	return &ed25519JWK{
+		PublicKey: base64.RawURLEncoding.EncodeToString(k),
+		Kty:       "OKP",
+	}
+}
+
+func ecdsaAlgorithmString(publicKey *ecdsa.PublicKey) string {
+	switch publicKey.Params().BitSize {
+	case 256:
+		return "ES256"
+	case 384:
+		return "ES384"
+	case 521:
+		return "ES512"
+	default:
+		return ""
+	}
+}
+
+func rsaAlgorithmString(publicKey *rsa.PublicKey) string {
+	switch bits := publicKey.N.BitLen(); {
+	case bits >= 4096:
+		return "RS512"
+	case bits >= 3072:
+		return "RS384"
+	case bits >= 2048:
+		return "RS256"
+	default:
+		return ""
+	}
+}
+
+func ed25519AlgorithmString() string {
+	return "EdDSA"
+}

--- a/pkg/crypto/dpop.go
+++ b/pkg/crypto/dpop.go
@@ -50,13 +50,21 @@ type DPoPProofBuilder struct {
 	errs          []error
 }
 
+func NewDPoPProof(publicKey any, privateKey any, method string, url string) (*DPoPProof, error) {
+	d := NewDPoPProofBuilder().
+		PublicKey(publicKey).
+		PrivateKey(privateKey).
+		Method(method).
+		Url(url)
+	return d.Build()
+}
+
 func (d *DPoPProof) String() string {
 	return string(*d)
 }
 
 func NewDPoPProofBuilder() (d *DPoPProofBuilder) {
-	d = &DPoPProofBuilder{}
-	return d
+	return new(DPoPProofBuilder)
 }
 
 func (d *DPoPProofBuilder) PublicKey(k any) *DPoPProofBuilder {

--- a/pkg/crypto/dpop_test.go
+++ b/pkg/crypto/dpop_test.go
@@ -1,0 +1,336 @@
+package crypto
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestCreateDpopProof(t *testing.T) {
+
+	privateKeyRSA, _ := rsa.GenerateKey(rand.Reader, 2048)
+	publicKeyRSA := &privateKeyRSA.PublicKey
+
+	privateKeyECDSA, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	publicKeyECDSA := &privateKeyECDSA.PublicKey
+
+	publicKeyEd25519, privateKeyEd25519, _ := ed25519.GenerateKey(rand.Reader)
+
+	tests := []struct {
+		name                  string
+		privateKey            any
+		publicKey             any
+		method                string
+		url                   string
+		expectedSigningMethod jwt.SigningMethod
+	}{
+		{
+			name:                  "create dpop header using rsa key",
+			privateKey:            privateKeyRSA,
+			publicKey:             publicKeyRSA,
+			method:                "POST",
+			url:                   "https://example.com",
+			expectedSigningMethod: jwt.SigningMethodRS256,
+		},
+		{
+			name:                  "create dpop header using ecdsa key",
+			privateKey:            privateKeyECDSA,
+			publicKey:             publicKeyECDSA,
+			method:                "POST",
+			url:                   "https://example.com",
+			expectedSigningMethod: jwt.SigningMethodES256,
+		},
+		{
+			name:                  "create dpop header using ed25519 key",
+			privateKey:            privateKeyEd25519,
+			publicKey:             publicKeyEd25519,
+			method:                "POST",
+			url:                   "https://example.com",
+			expectedSigningMethod: jwt.SigningMethodEdDSA,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// verify that CreateDpopProof does not return an error
+			// and that the generated token is not empty
+			got, err := CreateDpopProof(tt.privateKey, tt.publicKey, tt.method, tt.url)
+			if err != nil {
+				t.Errorf("CreateDpopProof() error = %v, wantErr %v", err, nil)
+			}
+			if got == "" {
+				t.Errorf("CreateDpopProof() got = %v, want %v", got, "not empty")
+			}
+
+			// parse the token and verify the signing key type
+			token, err := jwt.Parse(got, func(token *jwt.Token) (any, error) {
+				switch token.Method.(type) {
+				case *jwt.SigningMethodRSA:
+					if tt.expectedSigningMethod != jwt.SigningMethodRS256 {
+						return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+					}
+					return publicKeyRSA, nil
+				case *jwt.SigningMethodECDSA:
+					if tt.expectedSigningMethod != jwt.SigningMethodES256 {
+						return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+					}
+					return publicKeyECDSA, nil
+				case *jwt.SigningMethodEd25519:
+					if tt.expectedSigningMethod != jwt.SigningMethodEdDSA {
+						return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+					}
+					return publicKeyEd25519, nil
+				default:
+					return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+				}
+			})
+			if err != nil {
+				t.Errorf("jwt.Parse() = %v, want %v", err, nil)
+			}
+			if token == nil {
+				t.Errorf("token = %v, want %v", token, "not nil")
+			}
+
+			// verify that all parts of the token are populated
+			if token.Header == nil {
+				t.Errorf("token.Header = %v, want %v", token.Header, "not nil")
+			}
+			claims, ok := token.Claims.(jwt.MapClaims)
+			if !ok {
+				t.Errorf("token.Claims type = %v, want %v", token.Claims, "jwt.MapClaims")
+			}
+			if claims == nil {
+				t.Errorf("token.Claims = %v, want %v", token.Claims, "not nil")
+			}
+			if token.Signature == nil {
+				t.Errorf("token.Signature = %v, want %v", token.Signature, "not nil")
+			}
+		})
+	}
+}
+
+func TestCreateDpopProofError(t *testing.T) {
+	privateKeyRSA, _ := rsa.GenerateKey(rand.Reader, 2048)
+	publicKeyRSA := &privateKeyRSA.PublicKey
+
+	privateKeyECDSA, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	publicKeyECDSA := &privateKeyECDSA.PublicKey
+
+	tests := []struct {
+		name       string
+		privateKey any
+		publicKey  any
+		method     string
+		url        string
+	}{
+		{
+			name:       "create dpop header using public key as private key",
+			privateKey: publicKeyRSA,
+			publicKey:  publicKeyRSA,
+			method:     "POST",
+			url:        "https://example.com",
+		},
+		{
+			name:       "create dpop header using private key as public key",
+			privateKey: privateKeyRSA,
+			publicKey:  privateKeyRSA,
+			method:     "POST",
+			url:        "https://example.com",
+		},
+		{
+			name:       "create dpop header with non-matching key types",
+			privateKey: privateKeyRSA,
+			publicKey:  publicKeyECDSA,
+			method:     "POST",
+			url:        "https://example.com",
+		},
+		{
+			name:       "create dpop header using empty keys",
+			privateKey: nil,
+			publicKey:  nil,
+			method:     "POST",
+			url:        "https://example.com",
+		},
+		{
+			name:       "create dpop header with invalid keys",
+			privateKey: "1234",
+			publicKey:  "1234",
+			method:     "POST",
+			url:        "https://example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CreateDpopProof(tt.privateKey, tt.publicKey, tt.method, tt.url)
+			if err == nil {
+				t.Errorf("CreateDpopProof() error = %v, wantErr %v", err, "not nil")
+			}
+			if got != "" {
+				t.Errorf("CreateDpopProof() got = %v, want %v", got, "empty")
+			}
+		})
+	}
+}
+
+func TestConstructDpopToken(t *testing.T) {
+
+	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+	publicKey := &privateKey.PublicKey
+
+	tests := []struct {
+		name          string
+		jwk           any
+		alg           string
+		jti           string
+		method        string
+		url           string
+		signingMethod jwt.SigningMethod
+	}{
+		{
+			name:          "generate valid dpop token",
+			jwk:           convertPublicKeyToRsaJwk(publicKey),
+			alg:           rsaAlgorithmString(publicKey),
+			jti:           generateJTI(),
+			method:        "POST",
+			url:           "https://example.com",
+			signingMethod: jwt.SigningMethodRS256,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := constructDpopToken(tt.jwk, tt.alg, tt.jti, tt.method, tt.url, tt.signingMethod)
+			if got.Header == nil {
+				t.Errorf("got.Header = %v, want %v", got.Header, "not nil")
+			}
+			if got.Header["alg"] != tt.alg {
+				t.Errorf("got.Header[\"alg\"] = %v, want %v", got.Header["alg"], tt.alg)
+			}
+			if got.Header["typ"] != "dpop+jwt" {
+				t.Errorf("got.Header[\"typ\"] = %v, want %v", got.Header["typ"], "dpop+jwt")
+			}
+			if got.Header["jwk"] != tt.jwk {
+				t.Errorf("got.Header[\"jwk\"] = %v, want %v", got.Header["jwk"], tt.jwk)
+			}
+			if got.Claims == nil {
+				t.Errorf("got.Claims = %v, want %v", got.Claims, "not nil")
+			}
+			claims, ok := got.Claims.(jwt.MapClaims)
+			if !ok {
+				t.Errorf("got.Claims = %v, want %v", got.Claims, "jwt.MapClaims")
+			}
+			if claims["jti"] != tt.jti {
+				t.Errorf("claims\"jti\"] = %v, want %v", claims["jti"], tt.jti)
+			}
+			if claims["htm"] != tt.method {
+				t.Errorf("claims[\"htm\"] = %v, want %v", claims["htm"], tt.method)
+			}
+			if claims["htu"] != tt.url {
+				t.Errorf("claims[\"htu\"] = %v, want %v", claims["htu"], tt.url)
+			}
+			if claims["iat"] == nil {
+				t.Errorf("claims[\"iat\"] = %v, want %v", claims["iat"], "not nil")
+			}
+			if got.Method != tt.signingMethod {
+				t.Errorf("got.Method = %v, want %v", got.Method, tt.signingMethod)
+			}
+			signingString, _ := got.SigningString()
+			if signingString == "" {
+				t.Errorf("got.SigningString() = %v, want %v", signingString, "not empty")
+			}
+		})
+	}
+}
+
+func TestEcdsaAlgorithmString(t *testing.T) {
+
+	privateKey256, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	publicKey256 := &privateKey256.PublicKey
+
+	privateKey384, _ := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	publicKey384 := &privateKey384.PublicKey
+
+	privateKey512, _ := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	publicKey512 := &privateKey512.PublicKey
+
+	tests := []struct {
+		name     string
+		key      *ecdsa.PublicKey
+		expected string
+	}{
+		{
+			name:     "valid 256-bit ecdsa key",
+			key:      publicKey256,
+			expected: "ES256",
+		},
+		{
+			name:     "valid 384-bit ecdsa key",
+			key:      publicKey384,
+			expected: "ES384",
+		},
+		{
+			name:     "valid 521-bit ecdsa key",
+			key:      publicKey512,
+			expected: "ES512",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ecdsaAlgorithmString(tt.key)
+			if got != tt.expected {
+				t.Errorf("ecdsaAlgorithmString() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRsaAlgorithmString(t *testing.T) {
+
+	privateKey256, _ := rsa.GenerateKey(rand.Reader, 2048)
+	publicKey256 := &privateKey256.PublicKey
+
+	privateKey384, _ := rsa.GenerateKey(rand.Reader, 3072)
+	publicKey384 := &privateKey384.PublicKey
+
+	privateKey512, _ := rsa.GenerateKey(rand.Reader, 4096)
+	publicKey512 := &privateKey512.PublicKey
+
+	tests := []struct {
+		name     string
+		key      *rsa.PublicKey
+		expected string
+	}{
+		{
+			name:     "valid 2048-bit rsa key",
+			key:      publicKey256,
+			expected: "RS256",
+		},
+		{
+			name:     "valid 3072-bit rsa key",
+			key:      publicKey384,
+			expected: "RS384",
+		},
+		{
+			name:     "valid 4096-bit rsa key",
+			key:      publicKey512,
+			expected: "RS512",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rsaAlgorithmString(tt.key)
+			if got != tt.expected {
+				t.Errorf("rsaAlgorithmString() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/crypto/pem.go
+++ b/pkg/crypto/pem.go
@@ -1,0 +1,52 @@
+package crypto
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+)
+
+func ReadPEMBlockFromFile(filePath string) (*pem.Block, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM block")
+	}
+
+	return block, nil
+}
+
+func ParsePublicKeyPEMBlock(block *pem.Block) (any, error) {
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	return key, nil
+}
+
+func ParsePrivateKeyPEMBlock(block *pem.Block) (any, error) {
+	var key any
+	var err error
+	switch block.Type {
+	case "PRIVATE KEY":
+		key, err = x509.ParsePKCS8PrivateKey(block.Bytes)
+	case "RSA PRIVATE KEY":
+		key, err = x509.ParsePKCS1PrivateKey(block.Bytes)
+	case "EC PRIVATE KEY":
+		key, err = x509.ParseECPrivateKey(block.Bytes)
+	default:
+		return nil, fmt.Errorf("unsupported private key type: %s", block.Type)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return key, nil
+}

--- a/pkg/crypto/pem.go
+++ b/pkg/crypto/pem.go
@@ -22,6 +22,10 @@ func ReadPEMBlockFromFile(filePath string) (*pem.Block, error) {
 }
 
 func ParsePublicKeyPEMBlock(block *pem.Block) (any, error) {
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block provided")
+	}
+
 	key, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
 		return nil, err
@@ -31,6 +35,10 @@ func ParsePublicKeyPEMBlock(block *pem.Block) (any, error) {
 }
 
 func ParsePrivateKeyPEMBlock(block *pem.Block) (any, error) {
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block provided")
+	}
+
 	var key any
 	var err error
 	switch block.Type {

--- a/pkg/crypto/pem_test.go
+++ b/pkg/crypto/pem_test.go
@@ -1,0 +1,100 @@
+package crypto
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+)
+
+func TestParsePublicKeyPEMBlock(t *testing.T) {
+
+	privateKeyRSA, _ := rsa.GenerateKey(rand.Reader, 2048)
+	publicKeyRSA := &privateKeyRSA.PublicKey
+	x509RSA, _ := x509.MarshalPKIXPublicKey(publicKeyRSA)
+
+	privateKeyECDSA, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	publicKeyECDSA := &privateKeyECDSA.PublicKey
+	x509ECDSA, _ := x509.MarshalPKIXPublicKey(publicKeyECDSA)
+
+	publicKeyEd25519, _, _ := ed25519.GenerateKey(rand.Reader)
+	x509Ed25519, _ := x509.MarshalPKIXPublicKey(publicKeyEd25519)
+
+	pemBlockRSA := &pem.Block{Type: "PUBLIC KEY", Bytes: x509RSA}
+	pemBlockECDSA := &pem.Block{Type: "PUBLIC KEY", Bytes: x509ECDSA}
+	pemBlockEd25519 := &pem.Block{Type: "PUBLIC KEY", Bytes: x509Ed25519}
+	pemBlockInvalid := &pem.Block{Type: "PUBLIC KEY", Bytes: []byte("invalid")}
+	pemBlockUnsupported := &pem.Block{Type: "UNSUPPORTED PUBLIC KEY", Bytes: []byte("unsupported")}
+
+	tests := []struct {
+		name    string
+		block   *pem.Block
+		wantErr bool
+	}{
+		{"valid rsa public key", pemBlockRSA, false},
+		{"valid ecdsa public key", pemBlockECDSA, false},
+		{"valid ed25519 public key", pemBlockEd25519, false},
+		{"invalid public key", pemBlockInvalid, true},
+		{"unsupported public key header", pemBlockUnsupported, true},
+		{"empty pem block", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParsePublicKeyPEMBlock(tt.block)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParsePublicKeyPEMBlock() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestParsePrivateKeyPEMBlock(t *testing.T) {
+
+	privateKeyRSA, _ := rsa.GenerateKey(rand.Reader, 2048)
+	x509RSAPKCS1 := x509.MarshalPKCS1PrivateKey(privateKeyRSA)
+	x509RSAPKCS8, _ := x509.MarshalPKCS8PrivateKey(privateKeyRSA)
+
+	privateKeyECDSA, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	x509ECDSAEC, _ := x509.MarshalECPrivateKey(privateKeyECDSA)
+	x509ECDSAPKCS8, _ := x509.MarshalPKCS8PrivateKey(privateKeyECDSA)
+
+	_, privateKeyEd25519, _ := ed25519.GenerateKey(rand.Reader)
+	x509Ed25519, _ := x509.MarshalPKCS8PrivateKey(privateKeyEd25519)
+
+	pemBlockRSAPKCS1 := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509RSAPKCS1}
+	pemBlockRSAPKCS8 := &pem.Block{Type: "PRIVATE KEY", Bytes: x509RSAPKCS8}
+	pemBlockECDSAEC := &pem.Block{Type: "EC PRIVATE KEY", Bytes: x509ECDSAEC}
+	pemBlockECDSAPKCS8 := &pem.Block{Type: "PRIVATE KEY", Bytes: x509ECDSAPKCS8}
+	pemBlockEd25519 := &pem.Block{Type: "PRIVATE KEY", Bytes: x509Ed25519}
+	pemBlockInvalid := &pem.Block{Type: "PRIVATE KEY", Bytes: []byte("invalid")}
+	pemBlockUnsupported := &pem.Block{Type: "UNSUPPORTED PRIVATE KEY", Bytes: []byte("unsupported")}
+
+	tests := []struct {
+		name    string
+		block   *pem.Block
+		wantErr bool
+	}{
+		{"valid rsa private key pkcs1", pemBlockRSAPKCS1, false},
+		{"valid rsa private key pkcs8", pemBlockRSAPKCS8, false},
+		{"valid ecdsa private key ec", pemBlockECDSAEC, false},
+		{"valid ecdsa private key pkcs8", pemBlockECDSAPKCS8, false},
+		{"valid ed25519 private key", pemBlockEd25519, false},
+		{"invalid private key", pemBlockInvalid, true},
+		{"unsupported private key header", pemBlockUnsupported, true},
+		{"empty pem block", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParsePrivateKeyPEMBlock(tt.block)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParsePrivateKeyPEMBlock() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/crypto/pkce.go
+++ b/pkg/crypto/pkce.go
@@ -1,4 +1,4 @@
-package oidc
+package crypto
 
 import (
 	"crypto/rand"
@@ -7,7 +7,7 @@ import (
 	"math/big"
 )
 
-func randomInt(min, max int) int {
+func RandomInt(min, max int) int {
 	nBig, err := rand.Int(rand.Reader, big.NewInt(int64(max-min)))
 	if err != nil {
 		panic(err)
@@ -15,7 +15,7 @@ func randomInt(min, max int) int {
 	return int(nBig.Int64()) + min
 }
 
-func pkceCodeVerifier(n int) string {
+func CreatePkceCodeVerifier(n int) string {
 	if n < 32 || n > 96 {
 		panic("Code verifier length before base64 encoding must be between 32 and 96 bytes")
 	}
@@ -28,7 +28,7 @@ func pkceCodeVerifier(n int) string {
 	return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(b)
 }
 
-func pkceCodeChallenge(codeVerifier string) string {
+func CreatePkceCodeChallenge(codeVerifier string) string {
 	sha := sha256.Sum256([]byte(codeVerifier))
 	return base64.RawURLEncoding.EncodeToString(sha[:])
 }

--- a/pkg/crypto/pkce.go
+++ b/pkg/crypto/pkce.go
@@ -15,7 +15,7 @@ func RandomInt(min, max int) int {
 	return int(nBig.Int64()) + min
 }
 
-func CreatePkceCodeVerifier(n int) string {
+func GeneratePKCECodeVerifier(n int) string {
 	if n < 32 || n > 96 {
 		panic("Code verifier length before base64 encoding must be between 32 and 96 bytes")
 	}
@@ -28,7 +28,7 @@ func CreatePkceCodeVerifier(n int) string {
 	return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(b)
 }
 
-func CreatePkceCodeChallenge(codeVerifier string) string {
+func GeneratePKCECodeChallenge(codeVerifier string) string {
 	sha := sha256.Sum256([]byte(codeVerifier))
 	return base64.RawURLEncoding.EncodeToString(sha[:])
 }

--- a/pkg/crypto/pkce_test.go
+++ b/pkg/crypto/pkce_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestPkceCodeVerifier(t *testing.T) {
+func TestGeneratePKCECodeVerifier(t *testing.T) {
 	var tests = []struct {
 		name          string
 		generateBytes int
@@ -26,7 +26,7 @@ func TestPkceCodeVerifier(t *testing.T) {
 					t.Errorf("pkceCodeVerifier() recover = %v, wantPanic = %v", r, tt.wantPanic)
 				}
 			}()
-			gotBytes := len(CreatePkceCodeVerifier(tt.generateBytes))
+			gotBytes := len(GeneratePKCECodeVerifier(tt.generateBytes))
 			if gotBytes != tt.wantBytes {
 				t.Errorf("err got %v, want %v", gotBytes, tt.wantBytes)
 			}

--- a/pkg/crypto/pkce_test.go
+++ b/pkg/crypto/pkce_test.go
@@ -1,4 +1,4 @@
-package oidc
+package crypto
 
 import (
 	"testing"
@@ -26,7 +26,7 @@ func TestPkceCodeVerifier(t *testing.T) {
 					t.Errorf("pkceCodeVerifier() recover = %v, wantPanic = %v", r, tt.wantPanic)
 				}
 			}()
-			gotBytes := len(pkceCodeVerifier(tt.generateBytes))
+			gotBytes := len(CreatePkceCodeVerifier(tt.generateBytes))
 			if gotBytes != tt.wantBytes {
 				t.Errorf("err got %v, want %v", gotBytes, tt.wantBytes)
 			}

--- a/token_request.go
+++ b/token_request.go
@@ -21,6 +21,7 @@ type TokenRequest struct {
 	ClientSecret string          `schema:"client_secret,omitempty"`
 	RefreshToken string          `schema:"refresh_token,omitempty"`
 	AuthMethod   AuthMethodValue `schema:"-"` // not part of the request
+	DPoPHeader   string          `schema:"-"` // not part of the request
 }
 
 func (tReq *TokenRequest) Execute(tokenEndpoint string, verbose bool, httpClient *http.Client) (tResp *TokenResponse, err error) {
@@ -56,6 +57,10 @@ func (tReq *TokenRequest) Execute(tokenEndpoint string, verbose bool, httpClient
 		return nil, err
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	if tReq.DPoPHeader != "" {
+		req.Header.Add("DPoP", tReq.DPoPHeader)
+	}
 
 	if tReq.AuthMethod == AuthMethodClientSecretBasic {
 		req.SetBasicAuth(tReq.ClientID, tReq.ClientSecret)


### PR DESCRIPTION
This PR adds a `--dpop` command-line argument that - when present - will add a DPoP header to a token request that is made during an authorization code flow execution. This implements the client-part of RFC9449. This feature is most useful in combination with a resource server that expects to receive "DPoP-Bound Access Tokens".

In order to generate a "DPoP Proof" the user will also be required to provide a private/public keypair using `--private-key` and `--public-key` command-line arguments. DPoP does not allow using symmetric algorithms for signing the DPoP Proof.