### PR TITLE
feat: add test coverage to browser.go

### DIFF
--- a/authorization_request.go
+++ b/authorization_request.go
@@ -79,7 +79,7 @@ func (aReq *AuthorizationRequest) Execute(ctx context.Context, authEndpoint stri
 
 	log.Printf("authorization request: %s\n", requestURL)
 
-	browser := webflow.NewSystemBrowser()
+	browser := webflow.NewBrowser()
 	err = browser.Open(requestURL)
 	if err != nil {
 		log.Errorf("unable to open browser because %v, visit %s to continue\n", err, requestURL)

--- a/pkg/webflow/browser.go
+++ b/pkg/webflow/browser.go
@@ -1,22 +1,59 @@
 package webflow
 
-import "os/exec"
+import (
+	"fmt"
+	"os/exec"
+)
 
+// Browser defines an interface for opening URLs in a web browser.
+// Implementations should provide a method to open a URL.
 type Browser interface {
 	Open(url string) error
 }
 
-type SystemBrowser struct{}
+// SystemBrowser opens URLs using system-specific commands (e.g., xdg-open on Linux,
+// open on macOS, cmd /c start on Windows).
+type SystemBrowser struct {
+	RunCmd      func(prog string, args ...string) error
+	OpenBrowser func(url string, runCmd func(string, ...string) error) error
+}
 
+// Ensure SystemBrowser implements the Browser interface.
+var _ Browser = (*SystemBrowser)(nil)
+
+// NewBrowser returns a Browser implementation suitable for the current platform.
+func NewBrowser() Browser {
+	return NewSystemBrowser()
+}
+
+// NewSystemBrowser creates a new SystemBrowser instance with a default command runner.
+// It uses the runCmd function to execute system commands for opening URLs.
 func NewSystemBrowser() *SystemBrowser {
-	return &SystemBrowser{}
+	return &SystemBrowser{
+		RunCmd:      runCmd,
+		OpenBrowser: openBrowser,
+	}
 }
 
+// Open opens the specified URL in the system’s default browser.
+// It uses platform-specific commands (e.g., xdg-open on Linux, open on macOS).
+// Returns an error if the command is not found or fails to execute.
 func (s *SystemBrowser) Open(url string) error {
-	return openBrowser(url)
+	if s.RunCmd == nil {
+		s.RunCmd = runCmd
+	}
+	if s.OpenBrowser == nil {
+		s.OpenBrowser = openBrowser
+	}
+	return s.OpenBrowser(url, s.RunCmd)
 }
 
+// runCmd executes a command with the given program and arguments.
+// It checks if the program exists before running to provide better error messages.
 func runCmd(prog string, args ...string) error {
+	if _, err := exec.LookPath(prog); err != nil {
+		return fmt.Errorf("command %s not found: %w", prog, err)
+	}
 	cmd := exec.Command(prog, args...)
 	return cmd.Run()
 }

--- a/pkg/webflow/browser_darwin.go
+++ b/pkg/webflow/browser_darwin.go
@@ -1,5 +1,5 @@
 package webflow
 
-func openBrowser(url string) error {
+func openBrowser(url string, runCmd func(string, ...string) error) error {
 	return runCmd("open", url)
 }

--- a/pkg/webflow/browser_linux.go
+++ b/pkg/webflow/browser_linux.go
@@ -1,5 +1,5 @@
 package webflow
 
-func openBrowser(url string) error {
+func openBrowser(url string, runCmd func(string, ...string) error) error {
 	return runCmd("xdg-open", url)
 }

--- a/pkg/webflow/browser_test.go
+++ b/pkg/webflow/browser_test.go
@@ -1,0 +1,146 @@
+package webflow
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestSystemBrowserOpen tests the Open method for various platforms and scenarios.
+func TestSystemBrowserOpen(t *testing.T) {
+	tests := []struct {
+		name            string
+		url             string
+		mockOpenBrowser func(url string, runCmd func(string, ...string) error) error
+		wantErr         bool
+		wantErrMsg      string
+	}{
+		{
+			name: "Linux success",
+			url:  "https://example.com",
+			mockOpenBrowser: func(url string, runCmd func(string, ...string) error) error {
+				return runCmd("xdg-open", url)
+			},
+			wantErr: false,
+		},
+		{
+			name: "macOS success",
+			url:  "https://example.com",
+			mockOpenBrowser: func(url string, runCmd func(string, ...string) error) error {
+				return runCmd("open", url)
+			},
+			wantErr: false,
+		},
+		{
+			name: "Unsupported platform",
+			url:  "https://example.com",
+			mockOpenBrowser: func(_ string, _ func(string, ...string) error) error {
+				return errors.New("openBrowser: unsupported operating system: plan9")
+			},
+			wantErr:    true,
+			wantErrMsg: "unsupported operating system: plan9",
+		},
+		{
+			name: "Command not found",
+			url:  "https://example.com",
+			mockOpenBrowser: func(url string, runCmd func(string, ...string) error) error {
+				return runCmd("xdg-open", url)
+			},
+			wantErr:    true,
+			wantErrMsg: "command xdg-open not found",
+		},
+		{
+			name: "Invalid URL",
+			url:  "://invalid",
+			mockOpenBrowser: func(url string, runCmd func(string, ...string) error) error {
+				return runCmd("xdg-open", url)
+			},
+			wantErr:    true,
+			wantErrMsg: "failed to open browser",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set up RunCmd based on test case
+			var mockRunCmd func(prog string, args ...string) error
+			switch tt.name {
+			case "Linux success":
+				mockRunCmd = func(prog string, args ...string) error {
+					if prog != "xdg-open" || args[0] != tt.url {
+						return fmt.Errorf("expected xdg-open %s, got %s %v", tt.url, prog, args)
+					}
+					return nil
+				}
+			case "macOS success":
+				mockRunCmd = func(prog string, args ...string) error {
+					if prog != "open" || args[0] != tt.url {
+						return fmt.Errorf("expected open %s, got %s %v", tt.url, prog, args)
+					}
+					return nil
+				}
+			case "Command not found":
+				mockRunCmd = func(prog string, _ ...string) error {
+					return fmt.Errorf("command %s not found: exec: %q: executable file not found in $PATH", prog, prog)
+				}
+			case "Invalid URL":
+				mockRunCmd = func(_ string, _ ...string) error {
+					return errors.New("failed to open browser")
+				}
+			default: // Unsupported platform
+				mockRunCmd = func(_ string, _ ...string) error {
+					return errors.New("unexpected call to RunCmd on unsupported platform")
+				}
+			}
+
+			b := &SystemBrowser{
+				RunCmd:      mockRunCmd,
+				OpenBrowser: tt.mockOpenBrowser,
+			}
+			err := b.Open(tt.url)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("wantErr=%v, got err=%v", tt.wantErr, err)
+			}
+			if tt.wantErr && err != nil && !strings.Contains(err.Error(), tt.wantErrMsg) {
+				t.Errorf("expected error containing %q, got %q", tt.wantErrMsg, err.Error())
+			}
+		})
+	}
+}
+
+func TestNewBrowser(t *testing.T) {
+	b := NewBrowser()
+	if b == nil {
+		t.Fatal("NewBrowser returned nil")
+	}
+	if _, ok := b.(*SystemBrowser); !ok {
+		t.Errorf("NewBrowser returned %T, want *SystemBrowser", b)
+	}
+}
+
+func TestNewSystemBrowser(t *testing.T) {
+	b := NewSystemBrowser()
+	if b == nil {
+		t.Fatal("NewSystemBrowser returned nil")
+	}
+	if b.RunCmd == nil {
+		t.Error("NewSystemBrowser did not initialize RunCmd")
+	}
+	if b.OpenBrowser == nil {
+		t.Error("NewSystemBrowser did not initialize OpenBrowser")
+	}
+}
+
+func TestSystemBrowserDefaultRunCmd(t *testing.T) {
+	b := &SystemBrowser{
+		OpenBrowser: func(url string, runCmd func(string, ...string) error) error {
+			return runCmd("mythical-command", url)
+		},
+	} // RunCmd is nil
+	err := b.Open("https://example.com")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		// Expect an error due to command not being found in test environment
+		t.Errorf("expected command not found error, got %v", err)
+	}
+}

--- a/pkg/webflow/browser_unsupported.go
+++ b/pkg/webflow/browser_unsupported.go
@@ -8,6 +8,6 @@ import (
 	"runtime"
 )
 
-func openBrowser(url string) error {
+func openBrowser(url string, runCmd func(string, ...string) error) error {
 	return fmt.Errorf("openBrowser: unsupported operating system: %v", runtime.GOOS)
 }

--- a/pkg/webflow/browser_windows.go
+++ b/pkg/webflow/browser_windows.go
@@ -1,5 +1,5 @@
 package webflow
 
-func openBrowser(url string) error {
+func openBrowser(url string, runCmd func(string, ...string) error) error {
 	return runCmd("rundll32", "url.dll,FileProtocolHandler", url)
 }


### PR DESCRIPTION
This pull request refactors the browser-related code to enhance extensibility and testability, while also introducing comprehensive unit tests for the new functionality. The most important changes include replacing the `SystemBrowser` with a more flexible `Browser` interface, updating platform-specific browser opening functions to support dependency injection, and adding unit tests to validate the behavior of the new implementation.

### Refactoring for extensibility and testability:

* [`authorization_request.go`](diffhunk://#diff-09ffd35a35d1eeba724e5aa9fd69d5bff3146196dce8ef43858450387f55419dL82-R82): Replaced `webflow.NewSystemBrowser()` with `webflow.NewBrowser()` to use the new `Browser` interface, enabling greater flexibility in browser implementations.
* [`pkg/webflow/browser.go`](diffhunk://#diff-2c89f844a742eb5e48f5f3f3dc9c06ed90fcdbd079b8c04828d55f4e77cbeaf1L3-R56): Introduced the `Browser` interface and refactored `SystemBrowser` to support dependency injection for `RunCmd` and `OpenBrowser` functions. Added `NewBrowser` as a factory method to return platform-specific browser implementations.

### Updates to platform-specific browser functions:

* `pkg/webflow/browser_darwin.go`, `pkg/webflow/browser_linux.go`, `pkg/webflow/browser_windows.go`, `pkg/webflow/browser_unsupported.go`: Updated `openBrowser` functions to accept `runCmd` as a parameter, enabling easier testing and customization. [[1]](diffhunk://#diff-80bb3ebe43c14fb4f96a72effe7d87ad7a87d100754819eba5686a974085184aL3-R3) [[2]](diffhunk://#diff-56fc8904d32b0c89b191cb49d5d85cb7e3df0c2c4e8a8b40b86f15697ba4f769L3-R3) [[3]](diffhunk://#diff-e63984b775f94aea63e66dc9781dede925738b16da976f85d7891596dfc30f60L3-R3) [[4]](diffhunk://#diff-1d942207e49a851fd94f523784f9babb4ae8f2e35870f43ec36835a9e9f72f55L11-R11)

### Addition of unit tests:

* [`pkg/webflow/browser_test.go`](diffhunk://#diff-25fa75a8334bc60ac9ed96da573efc976eed37e31a70f74e90dc1083c0a7a1acR1-R146): Added unit tests to validate the behavior of `SystemBrowser` across different platforms and scenarios, including success cases, unsupported platforms, command not found errors, and invalid URLs. Also added tests for `NewBrowser` and `NewSystemBrowser` to ensure proper initialization.